### PR TITLE
Fix Jackson binding for "GetTogglesIT" test

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -28,7 +28,6 @@ import org.junit.*;
 import java.io.IOException;
 import java.util.Arrays;
 
-@Ignore
 public class GetTogglesIT {
 
     @ClassRule
@@ -70,7 +69,7 @@ public class GetTogglesIT {
         Assert.assertTrue(Arrays.asList(tr.enabled).contains("ENABLED"));
     }
 
-    public final class ToggleResponse {
+    public final static class ToggleResponse {
 
         public String[] enabled;
     }


### PR DESCRIPTION
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.097 s - in com.adobe.cq.cloud.testing.it.smoke.GetTogglesIT
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 3
[INFO] 
[INFO] 
[INFO] --- maven-failsafe-plugin:2.21.0:verify (default-verify) @ com.adobe.cq.cloud.testing.it.smoke ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:44 min
[INFO] Finished at: 2019-10-29T18:59:45+02:00
[INFO] ------------------------------------------------------------------------
```
The issue is fixed. @andreituicu, @volteanu, @dulvac, please take another look on it.