### PR TITLE
Add version validation smoke test using regex, check first paragraph text contents in about page fragment

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -25,6 +25,8 @@ import org.apache.sling.testing.clients.SlingHttpResponse;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.*;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -78,22 +80,36 @@ public class GetTogglesIT {
         SlingHttpResponse response = adminAuthor.doGet("mnt/overlay/granite/ui/content/shell/about.html", 200);
         final String regex = "^Adobe Experience Manager [\\d]{4}.[\\d]{2}.[\\d]+.[\\d]{8}T[\\d]{6}Z-[\\d]{6}$";
 
-      String content = response.getContent();
-      Document doc = DocumentBuilderFactory.newInstance()
+        String content = response.getContent();
+        Document doc = DocumentBuilderFactory.newInstance()
             .newDocumentBuilder()
             .parse(new InputSource(new StringReader(content)));
 
-      NodeList nodeList = doc.getElementsByTagName("p");
-      boolean match = false;
+        Element parentElement = doc.getDocumentElement();
+        boolean matchFound = checkElementMatchesRegex(regex, parentElement);
 
-      for (int i = 0; i < nodeList.getLength(); i++) {
-        String paragraphText = nodeList.item(i).getTextContent().trim();
-        if (paragraphText.matches(regex)) {
-          match = true;
-          break;
+        Assert.assertTrue("version regex " + regex + " not matching content in about page \n" + content, matchFound);
+    }
+
+    private boolean checkElementMatchesRegex(String regex, Node parentElement) {
+        boolean match = false;
+        if (parentElement.hasChildNodes()) {
+            NodeList childNodes = parentElement.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node item = childNodes.item(i);
+                String elementText = item.getTextContent().trim();
+                if (elementText.matches(regex)) {
+                    match = true;
+                    break;
+                } else {
+                    match = match || checkElementMatchesRegex(regex, item);
+                    if (match) {
+                        break;
+                    }
+                }
+            }
         }
-      }
-      Assert.assertTrue("version regex not matching content in about page \n" + content, match);
+        return match;
     }
 
     private void sharedTestResponseAlwaysContainsEnabledFlag(CQClient cqClient) throws ClientException, IOException {

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -25,6 +25,7 @@ import org.apache.sling.testing.clients.SlingHttpResponse;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.*;
 import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -77,12 +78,22 @@ public class GetTogglesIT {
         SlingHttpResponse response = adminAuthor.doGet("mnt/overlay/granite/ui/content/shell/about.html", 200);
         final String regex = "^Adobe Experience Manager [\\d]{4}.[\\d]{2}.[\\d]+.[\\d]{8}T[\\d]{6}Z-[\\d]{6}$";
 
-        Document doc = DocumentBuilderFactory.newInstance()
+      String content = response.getContent();
+      Document doc = DocumentBuilderFactory.newInstance()
             .newDocumentBuilder()
-            .parse(new InputSource(new StringReader(response.getContent())));
+            .parse(new InputSource(new StringReader(content)));
 
-        String aemVersionLine = doc.getElementsByTagName("p").item(0).getTextContent().trim();
-        Assert.assertTrue(aemVersionLine.matches(regex));
+      NodeList nodeList = doc.getElementsByTagName("p");
+      boolean match = false;
+
+      for (int i = 0; i < nodeList.getLength(); i++) {
+        String paragraphText = nodeList.item(i).getTextContent().trim();
+        if (paragraphText.matches(regex)) {
+          match = true;
+          break;
+        }
+      }
+      Assert.assertTrue("version regex not matching content in about page \n" + content, match);
     }
 
     private void sharedTestResponseAlwaysContainsEnabledFlag(CQClient cqClient) throws ClientException, IOException {

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -24,9 +24,16 @@ import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.*;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Arrays;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 public class GetTogglesIT {
 
@@ -60,6 +67,22 @@ public class GetTogglesIT {
     @Test
     public void testTogglesEndpointReturnsStaticEnabledFlagInJsonResponseOnPublish() throws ClientException, IOException {
         sharedTestResponseAlwaysContainsEnabledFlag(adminPublish);
+    }
+
+    /**
+     * Validate format of AEM version containing state qualifier using six digits
+     */
+    @Test
+    public void testAboutPageVersionFormatWithToggleQualifier() throws ClientException, IOException, SAXException, ParserConfigurationException {
+        SlingHttpResponse response = adminAuthor.doGet("mnt/overlay/granite/ui/content/shell/about.html", 200);
+        final String regex = "^Adobe Experience Manager [\\d]{4}.[\\d]{2}.[\\d]+.[\\d]{8}T[\\d]{6}Z-[\\d]{6}$";
+
+        Document doc = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(new InputSource(new StringReader(response.getContent())));
+
+        String aemVersionLine = doc.getElementsByTagName("p").item(0).getTextContent().trim();
+        Assert.assertTrue(aemVersionLine.matches(regex));
     }
 
     private void sharedTestResponseAlwaysContainsEnabledFlag(CQClient cqClient) throws ClientException, IOException {


### PR DESCRIPTION
Regex: `Adobe Experience Manager [\\d]{4}.[\\d]{2}.[\\d]+.[\\d]{8}T[\\d]{6}Z-[\\d]{6}`
Sample value: `Adobe Experience Manager 2019.11.2949.20191101T052100Z-000001`

Full page sample:

```
<coral-dialog  class="foundation-toggleable granite-help-about-dialog" variant="info" closable="on">
    <coral-dialog-header>About Adobe Experience Manager</coral-dialog-header>
    <coral-dialog-content class="u-coral-noPadding-vertical">
        <p>Adobe Experience Manager 2019.11.2949.20191101T052100Z-000001</p>
        <p>Copyright © 1993 - 2019 Adobe and its licensors. All rights reserved.</p>
        <p>Adobe and the Adobe logo are either registered trademarks or trademarks of Adobe in the United States and/or other countries. All other trademarks are the property of their respective owners.</p>
        <p>Third Party notices, terms and conditions pertaining to third party software can be found at  <a class="coral-Link" target="_blank" href="http://www.adobe.com/go/thirdparty">http://www.adobe.com/go/thirdparty</a> and are incorporated by reference.</p>
    </coral-dialog-content>
</coral-dialog>
```