### PR TITLE
DeepGetPageIT fails on paths with spaces

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/DeepGetPageIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/DeepGetPageIT.java
@@ -121,7 +121,7 @@ public class DeepGetPageIT {
         URI baseURI = client.getUrl();
         for (URI ref : client.getResourceRefs(path)) {
             if (isSameOrigin(baseURI, ref)) {
-                SlingHttpResponse response = client.doGet(ref.getPath());
+                SlingHttpResponse response = client.doGet(ref.getRawPath());
                 int statusCode = response.getStatusLine().getStatusCode();
                 assertEquals("Unexpected status returned from [" + ref + "]", 200, statusCode);
             }


### PR DESCRIPTION
## Problem description

First of all, the image source is properly url encoded in the page:

``` 
<img src="/content/dam/Screenshot%20from%202019-12-12%2008-58-32.png/_jcr_content/renditions/cq5dam.thumbnail.319.319.png?ch_ck=1576147828000" alt="Screenshot from 2019-12-12 08-58-32.png" class="">
```

When DeepGetPageIT inspects the page resources it's able to properly create an `URI` instance for `"/content/dam/Screenshot%20from%202019-12-12%2008-58-32.png"` because that is a properly url-encoded string.

In a second step the test is trying to actually load the page resource [1]. It does so by using `AbstractSlingClient.doGet(uri.getPath())`. The problem here is the use of `URI.getPath()`, because this call decodes the path element of the URI. This brings back the whitespace in the path and turns

```
/content/dam/Screenshot%20from%202019-12-12%2008-58-32.png
```
into

```
/content/dam/Screenshot from 2019-12-12 08-58-32.png
```
As this path is no longer url-encoded, the `AbstractSlingClient.doGet()` call fails to create it's own `URI` instance [2].

```
java.lang.IllegalArgumentException: java.net.URISyntaxException: Illegal character in path at index 23: /content/dam/Screenshot 2019-11-22 at 15.28.09.png/_jcr_content/renditions/cq5dam.thumbnail.319.319.png
	at com.adobe.cq.cloud.testing.it.smoke.DeepGetPageIT.verifyPageAndResources(DeepGetPageIT.java:124)
	at com.adobe.cq.cloud.testing.it.smoke.DeepGetPageIT.testAssetsAuthor(DeepGetPageIT.java:85)
```
Proposing to use `URI.getRawPath()` when calling `AbstractSlingClient.doGet()` which does not decode the path and passes the path properly encoded.

[1] https://github.com/adobe/aem-test-samples/blob/aem-cloud/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/DeepGetPageIT.java#L124
[2] https://github.com/apache/sling-org-apache-sling-testing-clients/blob/4f5307de06b714c9536747bdd8285225f6c3051a/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java#L136