### PR TITLE
Revert "[GRANITE-30855] XF Smoke test failing with timeout while validating release"

### DIFF
--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
@@ -129,7 +129,6 @@ public class XfSmokeIT {
     }
 
     @Test
-    @Ignore
     public void deleteExperienceFragmentTest() throws ClientException {
         final ExperienceFragmentsClient client = cqAuthorPublishClassRule.authorRule.getAdminClient(ExperienceFragmentsClient.class);
         for (XF_TEMPLATE predefinedTemplate : XF_TEMPLATE.values()) {
@@ -150,7 +149,6 @@ public class XfSmokeIT {
     }
 
     @Test
-    @Ignore
     public void createXFVariantTest() throws ClientException {
         final CQClient adminAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
         final ExperienceFragmentsClient adminXFClient = adminAuthor.adaptTo(ExperienceFragmentsClient.class);
@@ -187,7 +185,6 @@ public class XfSmokeIT {
     }
 
     @Test
-    @Ignore
     public void masterVariantDelete() throws ClientException {
         final CQClient adminAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
         final ExperienceFragmentsClient authorXFClient = adminAuthor.adaptTo(ExperienceFragmentsClient.class);
@@ -207,7 +204,6 @@ public class XfSmokeIT {
     }
 
     @Test
-    @Ignore
     public void variantDelete() throws ClientException {
         final CQClient authorAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
         final ExperienceFragmentsClient authorXFClient = authorAuthor.adaptTo(ExperienceFragmentsClient.class);


### PR DESCRIPTION
This reverts commit 7fdcd3e53a086de76e2f87b0ec5bed4b943f36a2.

...

Adding back XF Smoke Tests that were causing problems. Tested them on a skyline instance with release 2020.7.1305.20200719T152334Z and they worked.