### PR TITLE
Test CreatePageAsAuthorUserIT produces false negative if test page cr…

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
@@ -19,6 +19,7 @@ import com.adobe.cq.testing.client.security.CreateUserRule;
 import com.adobe.cq.testing.junit.rules.CQAuthorClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 import com.adobe.cq.testing.junit.rules.EmptyPage;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,7 +53,7 @@ public class CreatePageAsAuthorUserIT {
     @Test
     public void testCreatePageAsAuthor() throws InterruptedException {
         // This shows that it exists for the author user
-        userRule.getClient().pageExistsWithRetry(pageRule.getPath(), TIMEOUT);
+        Assert.assertTrue(String.format("Page %s not created within %s timeout", pageRule.getPath(), TIMEOUT), userRule.getClient().pageExistsWithRetry(pageRule.getPath(), TIMEOUT));
     }
 
 }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -44,8 +44,6 @@ public class GetTogglesIT {
     static CQClient adminPublish;
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);
-    @Rule
-    public Page root = new Page(cqBaseClassRule.authorRule);
 
     @BeforeClass
     public static void beforeClass() {


### PR DESCRIPTION
…eation fails

Proposing to fix the test CreatePageAsAuthorUserIT, which currently does not assert the call to _userRule.getClient().pageExistsWithRetry()_ , which is troublesome, in case the test page creation fails without exception, which is currently the case.

As well cleaning up test page creation in GetTogglesIT, as this test does not make use of the test page. 

As well proposing to update to a new release of aem-testing-clients containg https://github.com/adobe/aem-testing-clients/pull/48