### PR TITLE
Adapt pattern of version suffix by setting optional group

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -80,7 +80,7 @@ public class GetTogglesIT {
     @Test
     public void testAboutPageVersionFormatWithToggleQualifier() throws Exception {
         SlingHttpResponse response = adminAuthor.doGet("mnt/overlay/granite/ui/content/shell/about.html", 200);
-        final String regex = "^Adobe Experience Manager [\\d]{4}.[\\d]{1,2}.[\\d]+.[\\d]{8}T[\\d]{6}Z-[\\d]{6}";
+        final String regex = "^Adobe Experience Manager [\\d]{4}.[\\d]{1,2}.[\\d]+.[\\d]{8}T[\\d]{6}Z-[\\d]{6}(-[\\w]+)?$";
 
         String content = response.getContent()
                 .replaceAll("<!DOCTYPE((.|\n|\r)*?)>", "")


### PR DESCRIPTION

## Description

Remove set optional suffix of about page version.

## Related Issue

details in SKYOPS-10848

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested against live and upcoming versions.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
