### PR TITLE
CreatePageAsAuthorUserIT: Use path "/content/test-site" for creating test pages

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
@@ -39,6 +39,7 @@ public class CreatePageAsAuthorUserIT {
     private static final Logger LOG = LoggerFactory.getLogger(CreatePageAsAuthorUserIT.class);
 
     private static final int TIMEOUT = (int) MINUTES.toMillis(2);
+    private static final String SITE_ROOT_PATH = "/content/test-site";
     public static final String CONTENT_AUTHORS_GROUP = "content-authors";
 
     @ClassRule
@@ -59,10 +60,10 @@ public class CreatePageAsAuthorUserIT {
     @Test
     public void testCreatePageAsAuthor() throws InterruptedException, ClientException {
         String pageName = "testpage_" +  UUID.randomUUID();
-        String pagePath = "/content/" + pageName;
+        String pagePath = SITE_ROOT_PATH + "/" + pageName;
         try {
             SlingHttpResponse response = userRule.getClient().createPageWithRetry(pageName, "Page created by CreatePageAsAuthorUserIT",
-                    "/content", "", MINUTES.toMillis(1), 500, HttpStatus.SC_OK);
+                    SITE_ROOT_PATH, "", MINUTES.toMillis(1), 500, HttpStatus.SC_OK);
             pagePath = response.getSlingLocation();
             LOG.info("Created page at {}", pagePath);
 


### PR DESCRIPTION
with the last release, the "CreatePageAsAuthorUserIT" was rewritten changing it functionality drastically (although the commit was only named "Improve readability"). with the latest release the test:

* is really using a test user of content-author group (previously it seems to have used admin user)
* also the test page it creates is now located directly below /content

this lead to trouble on our AEMaaCS instances which had a custom ACL setup to not allow anyone (in the content-authors group) to have read/write access everywhere below /content. this must not be expected to be the case in a smoke test that is executed by default as "product functional test" without having the possibility to disable it.

this PR changes the test slightly to create the test page at least below `/content/test-site` making it easier to comply with custom ACLs setups where we allow read/write access to `/content/test-site` only, and not to everywhere below `/content`.