### PR TITLE
SITES-4315 Fixing ECP based on recent bug fix

### DIFF
--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
@@ -124,7 +124,7 @@ public class XfSmokeIT {
             Assert.assertEquals("First variation template is incorrect", masterVariant.getTemplateType(), predefinedTemplate);
             Assert.assertEquals("First variation title is incorrect", CREATE_VARIANT_TITLE, masterVariant.getTitle());
             Assert.assertTrue("First variation is not marked as master", masterVariant.isMasterVariant());
-            Assert.assertEquals("Variant tags should be empty", masterVariant.getTags().size(), 0);
+            Assert.assertEquals("Variant tags should contains at least one tag from initial content", 1, masterVariant.getTags().size());
         }
     }
 

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
@@ -124,7 +124,7 @@ public class XfSmokeIT {
             Assert.assertEquals("First variation template is incorrect", masterVariant.getTemplateType(), predefinedTemplate);
             Assert.assertEquals("First variation title is incorrect", CREATE_VARIANT_TITLE, masterVariant.getTitle());
             Assert.assertTrue("First variation is not marked as master", masterVariant.isMasterVariant());
-            Assert.assertEquals("Variant tags should contains at least one tag from initial content", 1, masterVariant.getTags().size());
+            Assert.assertEquals("Variant tags should contain at least one tag from the initial content", 1, masterVariant.getTags().size());
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

SITES-4315 fixed the issue that initial content tags where not respected, this test need an update so that it validate the default tag is present.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
