### PR TITLE
 Bump aem-testing-clients to 1.0.5

### DIFF
--- a/cf-smoke/pom.xml
+++ b/cf-smoke/pom.xml
@@ -226,7 +226,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>0.2.2</version>
+            <version>1.0.5</version>
         </dependency>
 
         <!-- logging -->

--- a/smoke/pom.xml
+++ b/smoke/pom.xml
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.5</version>
         </dependency>
 
         <!-- logging -->

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
@@ -21,7 +21,7 @@ import com.adobe.cq.testing.junit.rules.CQRule;
 import com.adobe.cq.testing.junit.rules.Page;
 import com.adobe.cq.testing.junit.rules.TemporaryContentAuthorGroup;
 import com.adobe.cq.testing.junit.rules.TemporaryUser;
-import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
@@ -84,11 +84,11 @@ public class CreatePageAsAuthorUserIT {
                 throw new AssumptionViolatedException("Author User " + userRule.getClient().getUser() + " not authorized to create page. Skipping...");
             }
             pagePath = response.getSlingLocation();
-            if (Strings.isNullOrEmpty(pagePath)) {
+            if (StringUtils.isEmpty(pagePath)) {
                 pagePath = response.getSlingPath();
             }
             String expectedResponseLike = "[...] <a href=\""  + pagePathExpected +"\" id=\"Location\">" + pagePathExpected + "</a> [...]";
-            assertFalse("Not able to get created page path from sling response. Expected response like " + expectedResponseLike, Strings.isNullOrEmpty(pagePath));
+            assertFalse("Not able to get created page path from sling response. Expected response like " + expectedResponseLike, StringUtils.isEmpty(pagePath));
             LOG.info("Created page at {}", pagePath);
 
             // This shows that it exists for the author user

--- a/wcm-smoke/pom.xml
+++ b/wcm-smoke/pom.xml
@@ -232,7 +232,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>0.2.2</version>
+            <version>1.0.5</version>
         </dependency>
 
         <!-- logging -->

--- a/xf-smoke/pom.xml
+++ b/xf-smoke/pom.xml
@@ -226,7 +226,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>0.2.2</version>
+            <version>1.0.5</version>
         </dependency>
 
         <!-- logging -->


### PR DESCRIPTION
Fixes:
* SLING-11131 - Remove Guava Dependency for CVE-2018-10237 and CVE-2020-8908
* SLING-11124 - Update Apache HTTP Client Dependency for CVE-2020-13956
* Allow to set "forceBasicAuth" for author and publish instance separately

## Motivation and Context

* Address CVEs in transitive dependencies.
* Include new change from aem-testing-clients

## How Has This Been Tested?

* Executed all changed modules against an AEM as a Cloud Service vanilla environment.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.