### PR TITLE
Rename test and add sutiable checks and exceptions

### DIFF
--- a/smoke/README.md
+++ b/smoke/README.md
@@ -14,12 +14,12 @@ of this repository.
 | Exceptions           | Error Code                  | Reason                                                             |
 |----------------------|-----------------------------|--------------------------------------------------------------------|
 | PublishException     | PAGE_NOT_AVAILABLE          | Activated page not available on publish                            |
-|                      | PAGE_AVAILABLE              | Deactivated page not available on publish                          |
+|                      | PAGE_AVAILABLE              | Deactivated page still available on publish                        |
 | ReplicationException | QUEUE_BLOCKED               | Replication queue blocked before test                              |
 |                      | ACTIVATION_REQUEST_FAILED   | Replication action failed                                          |
 |                      | DEACTIVATION_REQUEST_FAILED | Deactivation action failed                                         |
-|                      | ITEM_NOT_REPLICATED         | Item replicated still available on agent queues                    |
-|                      | REPLICATION_UNAVAILABLE     | Replication agents not available                                   |
+|                      | ITEM_NOT_REPLICATED         | Item to be replicated still available on agent queues              |
+|                      | REPLICATION_UNAVAILABLE     | Replication agents not available before test                       |
 | ServiceException     | AUTHOR_DOWN                 | Author is down before test                                         |
 |                      | PUBLISH_DOWN                | Publish is down before test                                        |
 | SmokeTestException   | GENERIC                     | Any generic exception. Mostly connection problems with the service |

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -6,3 +6,20 @@ This is a collection of generic smoke tests to validate the basic functionality 
 
 For details check the main [README.md](../README.md#run-the-test-against-your-aem-cloud-service-author-and-publish-tiers)
 of this repository.
+
+## Exceptions
+
+### Test - PublishEndToEndIT
+
+| Exceptions           | Error Code                  | Reason                                                             |
+|----------------------|-----------------------------|--------------------------------------------------------------------|
+| PublishException     | PAGE_NOT_AVAILABLE          | Activated page not available on publish                            |
+|                      | PAGE_AVAILABLE              | Deactivated page not available on publish                          |
+| ReplicationException | QUEUE_BLOCKED               | Replication queue blocked before test                              |
+|                      | ACTIVATION_REQUEST_FAILED   | Replication action failed                                          |
+|                      | DEACTIVATION_REQUEST_FAILED | Deactivation action failed                                         |
+|                      | ITEM_NOT_REPLICATED         | Item replicated still available on agent queues                    |
+|                      | REPLICATION_UNAVAILABLE     | Replication agents not available                                   |
+| ServiceException     | AUTHOR_DOWN                 | Author is down before test                                         |
+|                      | PUBLISH_DOWN                | Publish is down before test                                        |
+| SmokeTestException   | GENERIC                     | Any generic exception. Mostly connection problems with the service |

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -18,8 +18,8 @@ of this repository.
 | ReplicationException | QUEUE_BLOCKED               | Replication queue blocked before test                              |
 |                      | ACTIVATION_REQUEST_FAILED   | Replication action failed                                          |
 |                      | DEACTIVATION_REQUEST_FAILED | Deactivation action failed                                         |
-|                      | ITEM_NOT_REPLICATED         | Item to be replicated still available on agent queues              |
-|                      | REPLICATION_UNAVAILABLE     | Replication agents not available before test                       |
-| ServiceException     | AUTHOR_DOWN                 | Author is down before test                                         |
-|                      | PUBLISH_DOWN                | Publish is down before test                                        |
+|                      | ACTION_NOT_REPLICATED       | Replication action still pending in agent queues                   |
+|                      | REPLICATION_NOT_AVAILABLE   | Replication agents not available before test                       |
+| ServiceException     | AUTHOR_NOT_AVAILABLE        | Author is not available before test                                |
+|                      | PUBLISH_NOT_AVAILABLE       | Publish is not available before test                               |
 | SmokeTestException   | GENERIC                     | Any generic exception. Mostly connection problems with the service |

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
@@ -55,7 +55,7 @@ public class PublishEndToEndIT {
     public ContentPublishRule
         contentPublishRule = new ContentPublishRule(root, cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);
 
-	/**
+        /**
      * Activates a page as admin, then deactivates it.
      * Verifies:
      * <ul>

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
@@ -44,8 +44,8 @@ import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 
-public class ReplicationIT {
-    private Logger log = LoggerFactory.getLogger(ReplicationIT.class);
+public class PublishEndToEndIT {
+    private Logger log = LoggerFactory.getLogger(PublishEndToEndIT.class);
 
     private static final long TIMEOUT = TimeUnit.MINUTES.toMillis(5);
     private static final long TIMEOUT_PER_TRY = TimeUnit.MINUTES.toMillis(1);
@@ -102,37 +102,6 @@ public class ReplicationIT {
         } catch (Exception e) {
             new Polling(this::activateAndDeactivate).poll(TIMEOUT, 500);
         }
-    }
-    
-    /**
-     * Activates a page as admin, than deletes it. Verifies that deleted page gets removed from publish.
-     *
-     * @throws Exception if an error occurred
-     */
-    @Test
-    public void testActivateAndDelete() throws Exception {
-
-        // This is a workaround for correctly detecting assumption violations.
-        // Any AssumptionViolatedException throw by the the Callable will be
-        // swallowed by the Poller and wrapped in a TimeoutException. As a
-        // consequence, the test will be marked as failed instead of skipped.
-
-        try {
-            activateAndDelete();
-        } catch (AssumptionViolatedException e) {
-            throw e;
-        } catch (Exception e) {
-            new Polling(this::activateAndDelete).poll(TIMEOUT, 500);
-        }
-    }
-    
-    private boolean activateAndDelete() throws Exception {
-        rClient.activate(root.getPath());
-        checkPage(SC_OK);
-
-        adminAuthor.deletePage(new String[]{root.getPath()}, true, false);
-        checkPage(SC_NOT_FOUND);
-        return true;
     }
     
     private boolean activateAndDeactivate() throws Exception {

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
@@ -19,6 +19,7 @@ package com.adobe.cq.cloud.testing.it.smoke;
 import java.util.concurrent.TimeUnit;
 
 import com.adobe.cq.cloud.testing.it.smoke.rules.ContentPublishRule;
+import com.adobe.cq.cloud.testing.it.smoke.rules.ServiceAccessibleRule;
 import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 import com.adobe.cq.testing.junit.rules.Page;
@@ -27,6 +28,7 @@ import org.junit.AssumptionViolatedException;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 /**
  * End to end publication test.
@@ -42,10 +44,13 @@ public class PublishEndToEndIT {
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);
-
-    @Rule
+    
     public Page root = new Page(cqBaseClassRule.authorRule);
-
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule(new ServiceAccessibleRule(cqBaseClassRule.authorRule))
+        .around(new ServiceAccessibleRule(cqBaseClassRule.publishRule))
+        .around(root);
+    
     @Rule
     public ContentPublishRule
         contentPublishRule = new ContentPublishRule(root, cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Adobe Systems Incorporated
+ * Copyright 2022 Adobe Systems Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,46 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.adobe.cq.cloud.testing.it.smoke;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import com.adobe.cq.testing.client.CQClient;
-import com.adobe.cq.testing.client.ReplicationClient;
+import com.adobe.cq.cloud.testing.it.smoke.rules.ContentPublishRule;
 import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 import com.adobe.cq.testing.junit.rules.Page;
-import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.http.NameValuePair;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.sling.testing.clients.ClientException;
-import org.apache.sling.testing.clients.SlingHttpResponse;
 import org.apache.sling.testing.clients.util.poller.Polling;
 import org.junit.AssumptionViolatedException;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import static org.apache.http.HttpStatus.SC_NOT_FOUND;
-import static org.apache.http.HttpStatus.SC_OK;
-import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
-
+/**
+ * End to end publication test.
+ * 
+ * A test page is published from author and publication is validated through the AEM
+ * publish ingress (CDN -&gt; Dispatcher -&gt; AEM publish tier).
+ */
 public class PublishEndToEndIT {
-    private Logger log = LoggerFactory.getLogger(PublishEndToEndIT.class);
-
-    private static final long TIMEOUT = TimeUnit.MINUTES.toMillis(5);
-    private static final long TIMEOUT_PER_TRY = TimeUnit.MINUTES.toMillis(1);
-
-    private static final String DIST_AGENTS_PATH = "/libs/sling/distribution/services/agents";
-    private static final String PUBLISH_DIST_AGENT = "publish";
-
+    protected static final long TIMEOUT = TimeUnit.MINUTES.toMillis(1);
+    
     @ClassRule
     public static CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
 
@@ -62,28 +46,18 @@ public class PublishEndToEndIT {
     @Rule
     public Page root = new Page(cqBaseClassRule.authorRule);
 
-    static CQClient adminAuthor;
-    static CQClient adminPublish;
-    static CQClient anonymousPublish;
-
-    private static ReplicationClient rClient;
-
-    @BeforeClass
-    public static void beforeClass() throws ClientException {
-        adminAuthor = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
-        adminPublish = cqBaseClassRule.publishRule.getAdminClient(CQClient.class);
-        anonymousPublish = cqBaseClassRule.publishRule.getClient(CQClient.class, null, null);
-        rClient = adminAuthor.adaptTo(ReplicationClient.class);
-    }
-
-    @Before
-    public void before() throws TimeoutException, InterruptedException {
-        new Polling(this::checkContentDistributionAgentExists)
-        	.poll(TIMEOUT, 500);
-    }
+    @Rule
+    public ContentPublishRule
+        contentPublishRule = new ContentPublishRule(root, cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);
 
 	/**
-     * Activates a page as admin, then deactivates it. Verifies that the page gets removed from publish.
+     * Activates a page as admin, then deactivates it.
+     * Verifies:
+     * <ul>
+     *      <li>That the replication queue is empty</li>
+     *      <li>After activation, that the page is accessible via the publish ingress</li>
+     *      <li>After deactivation, that the page is no longer accessible via the publish ingress and that the queue is empty</li>
+     * </ul>
      *
      * @throws Exception if an error occurred
      */
@@ -91,7 +65,7 @@ public class PublishEndToEndIT {
     public void testActivateAndDeactivate() throws Exception {
 
         // This is a workaround for correctly detecting assumption violations.
-        // Any AssumptionViolatedException throw by the the Callable will be
+        // Any AssumptionViolatedException throw by the Callable will be
         // swallowed by the Poller and wrapped in a TimeoutException. As a
         // consequence, the test will be marked as failed instead of skipped.
 
@@ -100,62 +74,19 @@ public class PublishEndToEndIT {
         } catch (AssumptionViolatedException e) {
             throw e;
         } catch (Exception e) {
-            new Polling(this::activateAndDeactivate).poll(TIMEOUT, 500);
+            new Polling(() -> activateAndDeactivate()).poll(TIMEOUT, 500);
         }
     }
-    
-    private boolean activateAndDeactivate() throws Exception {
-	    rClient.activate(root.getPath());
-	    checkPage(SC_OK);
-	    rClient.deactivate(root.getPath(), SC_OK);
-	    checkPage(SC_NOT_FOUND);
-	    return true;
-	}
 
-	/**
-     * Checks that a GET on the page on publish has the {{expectedStatus}} in the response
+    /**
+     * Execute activate and deactivate on publish
      *
-     * @throws Exception if an error occurred
+     * @return true if success
+     * @throws Exception if exception occurs
      */
-    private void checkPage(boolean skipDispatcherCache, final int...  expectedStatus) throws Exception {
-        final String path = root.getPath() + ".html";
-        log.info("Checking page {} returns status {}", adminPublish.getUrl(path), expectedStatus);
-        SlingHttpResponse res = null;
-        final List<NameValuePair> queryParams = skipDispatcherCache
-                ? Collections.singletonList(
-                new BasicNameValuePair("timestamp", String.valueOf(System.currentTimeMillis())))
-                : Collections.emptyList();
-
-        res = adminPublish.doGet(path, queryParams, Collections.emptyList());
-        if (null != res && res.getStatusLine().getStatusCode() == SC_UNAUTHORIZED) {
-            throw new AssumptionViolatedException("Publish requires auth for (SAML?). Skipping...");
-        }
-
-        new Polling() {
-            @Override
-            public Boolean call() throws Exception {
-                final List<NameValuePair> queryParams = skipDispatcherCache
-                        ? Collections.singletonList(
-                            new BasicNameValuePair("timestamp", String.valueOf(System.currentTimeMillis())))
-                        : Collections.emptyList();
-                adminPublish.doGet(path, queryParams, Collections.emptyList(), expectedStatus);
-                return true;
-            }
-        }.poll(TIMEOUT_PER_TRY, 1000);
+    private boolean activateAndDeactivate() throws Exception {
+        contentPublishRule.activateAssertPublish();
+        contentPublishRule.deactivateAssertPublish();
+        return true;
     }
-
-    private void checkPage(final int... expectedStatus) throws Exception {
-        checkPage(true, expectedStatus);
-    }
-
-	private Boolean checkContentDistributionAgentExists() throws ClientException {
-		JsonNode agents = adminAuthor.doGetJson(DIST_AGENTS_PATH, 3);
-		log.info("Replication agents list: {}", agents);
-		if (agents.path(PUBLISH_DIST_AGENT).isMissingNode()) {
-		    log.warn("Default distribution agent {} is missing from the distribution list", PUBLISH_DIST_AGENT);
-		    return false;
-		}
-		return true;
-	}
-
 }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/PublishException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/PublishException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.exception;
+
+/**
+ * Exception on publish page check
+ */
+public class PublishException extends SmokeTestException {
+    public static final String PAGE_NOT_AVAILABLE = "PAGE_NOT_AVAILABLE";
+    public static final String PAGE_AVAILABLE = "PAGE_AVAILABLE";
+
+    public PublishException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+    
+    public PublishException(String errorCode, String message, Throwable t) {
+        super(errorCode, message, t);
+    }
+
+    public static String getPageErrorCode(int expectedStatus) {
+        if (expectedStatus == 200) {
+            return PAGE_NOT_AVAILABLE;
+        }
+        return PAGE_AVAILABLE;
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ReplicationException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ReplicationException.java
@@ -20,8 +20,8 @@ public class ReplicationException extends SmokeTestException {
     public static final String QUEUE_BLOCKED = "QUEUE_BLOCKED";
     public static final String ACTIVATION_REQUEST_FAILED = "ACTIVATION_REQUEST_FAILED";
     public static final String DEACTIVATION_REQUEST_FAILED = "DEACTIVATION_REQUEST_FAILED";
-    public static final String ITEM_NOT_REPLICATED = "ITEM_NOT_REPLICATED";
-    public static final String REPLICATION_UNAVAILABLE = "REPLICATION_UNAVAILABLE";
+    public static final String ACTION_NOT_REPLICATED = "ACTION_NOT_REPLICATED";
+    public static final String REPLICATION_NOT_AVAILABLE = "REPLICATION_NOT_AVAILABLE";
 
     public ReplicationException(String errorCode, String message) {
         super(errorCode, message);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ReplicationException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ReplicationException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.exception;
+
+public class ReplicationException extends SmokeTestException {
+    public static final String QUEUE_BLOCKED = "QUEUE_BLOCKED";
+    public static final String ACTIVATION_REQUEST_FAILED = "ACTIVATION_REQUEST_FAILED";
+    public static final String DEACTIVATION_REQUEST_FAILED = "DEACTIVATION_REQUEST_FAILED";
+    public static final String ITEM_NOT_REPLICATED = "ITEM_NOT_REPLICATED";
+    public static final String REPLICATION_UNAVAILABLE = "REPLICATION_UNAVAILABLE";
+
+    public ReplicationException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public ReplicationException(String errorCode, String message, Throwable t) {
+        super(errorCode, message, t);
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ServiceException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ServiceException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.exception;
+
+public class ServiceException extends SmokeTestException {
+    public static final String SUFFIX = "_DOWN";
+    
+    public ServiceException(String errorCode, String message) {
+        super(errorCode, message);
+    }
+    public ServiceException(String errorCode, String message, Throwable t) {
+        super(errorCode, message, t);
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ServiceException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ServiceException.java
@@ -17,7 +17,7 @@
 package com.adobe.cq.cloud.testing.it.smoke.exception;
 
 public class ServiceException extends SmokeTestException {
-    public static final String SUFFIX = "_DOWN";
+    public static final String SUFFIX = "_NOT_AVAILABLE";
     
     public ServiceException(String errorCode, String message) {
         super(errorCode, message);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/SmokeTestException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/SmokeTestException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.exception;
+
+public class SmokeTestException extends Exception {
+    public static final String GENERIC = "GENERIC";
+    
+    private final String errorCode;
+    
+    public SmokeTestException(String errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+    
+    public SmokeTestException(String errorCode, String message, Throwable t) {
+        super(message, t);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return getErrorCode() + ": " + super.getMessage();
+    }
+}
+ 

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
@@ -76,6 +76,7 @@ public class ReplicationClient extends CQClient {
      */
     public ReplicationResponse activate(String nodePath) throws SmokeTestException {
         try {
+            log.info("Activating {}", nodePath);
             ReplicationResponse response = ReplicationResponse.from(activateInternal("", nodePath));
             if (response.getCode() != HttpStatus.SC_OK) {
                 throw getReplicationException(ACTIVATION_REQUEST_FAILED, response.getMessage(), null);
@@ -96,6 +97,7 @@ public class ReplicationClient extends CQClient {
      */
     public ReplicationResponse deactivate(String pagePath) throws SmokeTestException {
         try {
+            log.info("De-Activating {}", pagePath);
             ReplicationResponse response = ReplicationResponse.from(deactivateInternal("", pagePath));
             if (response.getCode() != HttpStatus.SC_OK) {
                 throw getReplicationException(DEACTIVATION_REQUEST_FAILED, response.getMessage(), null);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
@@ -77,7 +77,7 @@ public class ReplicationClient extends CQClient {
     public ReplicationResponse activate(String nodePath) throws SmokeTestException {
         try {
             log.info("Activating {}", nodePath);
-            ReplicationResponse response = ReplicationResponse.from(activateInternal("", nodePath));
+            ReplicationResponse response = ReplicationResponse.from(activateInternal("Activate", "", nodePath));
             if (response.getCode() != HttpStatus.SC_OK) {
                 throw getReplicationException(ACTIVATION_REQUEST_FAILED, response.getMessage(), null);
             }
@@ -98,7 +98,7 @@ public class ReplicationClient extends CQClient {
     public ReplicationResponse deactivate(String pagePath) throws SmokeTestException {
         try {
             log.info("De-Activating {}", pagePath);
-            ReplicationResponse response = ReplicationResponse.from(deactivateInternal("", pagePath));
+            ReplicationResponse response = ReplicationResponse.from(activateInternal("Deactivate", "", pagePath));
             if (response.getCode() != HttpStatus.SC_OK) {
                 throw getReplicationException(DEACTIVATION_REQUEST_FAILED, response.getMessage(), null);
             }
@@ -109,19 +109,9 @@ public class ReplicationClient extends CQClient {
         }
     }
 
-    private SlingHttpResponse deactivateInternal(String agent, String pagePath) throws ClientException {
+    private SlingHttpResponse activateInternal(String cmd, String agent, String nodePath) throws ClientException {
         FormEntityBuilder formEntityBuilder =
-            FormEntityBuilder.create().addParameter("cmd", "Deactivate").addParameter("_charset_", "utf-8").addParameter("path", pagePath).addParameter("sync", String.valueOf(true));
-        if (StringUtils.isNotBlank(agent)) {
-            formEntityBuilder.addParameter("agentId", agent);
-        }
-
-        return this.doPost("/bin/replicate.json", formEntityBuilder.build(), Collections.emptyList());
-    }
-
-    private SlingHttpResponse activateInternal(String agent, String nodePath) throws ClientException {
-        FormEntityBuilder formEntityBuilder =
-            FormEntityBuilder.create().addParameter("cmd", "Activate").addParameter("_charset_", "utf-8").addParameter("path", nodePath).addParameter("sync", String.valueOf(true));
+            FormEntityBuilder.create().addParameter("cmd", cmd).addParameter("_charset_", "utf-8").addParameter("path", nodePath).addParameter("sync", String.valueOf(true));
         if (StringUtils.isNotBlank(agent)) {
             formEntityBuilder.addParameter("agentId", agent);
         }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.replication;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException;
+import com.adobe.cq.cloud.testing.it.smoke.exception.SmokeTestException;
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.Agent;
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.Agents;
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.Queue;
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.ReplicationResponse;
+import com.adobe.cq.cloud.testing.it.smoke.rules.ContentPublishRule;
+import com.adobe.cq.testing.client.CQClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingClientConfig;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.apache.sling.testing.clients.util.FormEntityBuilder;
+import org.apache.sling.testing.clients.util.HttpUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.ACTIVATION_REQUEST_FAILED;
+import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.DEACTIVATION_REQUEST_FAILED;
+import static com.adobe.cq.cloud.testing.it.smoke.exception.SmokeTestException.GENERIC;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+/**
+ * Extension of CQClient to add replication methods
+ */
+public class ReplicationClient extends CQClient {
+    private static final Logger log = LoggerFactory.getLogger(ContentPublishRule.class);
+
+    protected static final String DIST_AGENTS_PATH = "/libs/sling/distribution/services/agents";
+    protected static final String PUBLISH_DIST_AGENT = "publish";
+
+    protected static final String PUB_QUEUES_PATH = DIST_AGENTS_PATH + "/" + PUBLISH_DIST_AGENT;
+
+    public ReplicationClient(CloseableHttpClient http, SlingClientConfig config) throws ClientException {
+        super(http, config);
+    }
+
+    public ReplicationClient(URI serverUrl, String user, String password) throws ClientException {
+        super(serverUrl, user, password);
+    }
+
+    /**
+     * Activates the given path on author
+     *
+     * @param nodePath the path to activate
+     * @return a replication response containing status and message
+     * @throws SmokeTestException exception containing details
+     */
+    public ReplicationResponse activate(String nodePath) throws SmokeTestException {
+        try {
+            ReplicationResponse response = ReplicationResponse.from(activateInternal("", nodePath));
+            if (response.getCode() != HttpStatus.SC_OK) {
+                throw getReplicationException(ACTIVATION_REQUEST_FAILED, response.getMessage(), null);
+            }
+            log.info("Activation response received {}", response);
+            return response;
+        } catch (Exception e) {
+            throw getGenericException("Exception during activation", e);
+        }
+    }
+
+    /**
+     * Deactivates a given path on author
+     *
+     * @param pagePath the path to deactivate
+     * @return a replication response containing status and message
+     * @throws SmokeTestException exception containing error details if any
+     */
+    public ReplicationResponse deactivate(String pagePath) throws SmokeTestException {
+        try {
+            ReplicationResponse response = ReplicationResponse.from(deactivateInternal("", pagePath));
+            if (response.getCode() != HttpStatus.SC_OK) {
+                throw getReplicationException(DEACTIVATION_REQUEST_FAILED, response.getMessage(), null);
+            }
+            log.info("De-Activation response received {}", response);
+            return response;
+        } catch (Exception e) {
+            throw getGenericException("Exception during deactivation", e);
+        }
+    }
+
+    private SlingHttpResponse deactivateInternal(String agent, String pagePath) throws ClientException {
+        FormEntityBuilder formEntityBuilder =
+            FormEntityBuilder.create().addParameter("cmd", "Deactivate").addParameter("_charset_", "utf-8").addParameter("path", pagePath).addParameter("sync", String.valueOf(true));
+        if (StringUtils.isNotBlank(agent)) {
+            formEntityBuilder.addParameter("agentId", agent);
+        }
+
+        return this.doPost("/bin/replicate.json", formEntityBuilder.build(), Collections.emptyList());
+    }
+
+    private SlingHttpResponse activateInternal(String agent, String nodePath) throws ClientException {
+        FormEntityBuilder formEntityBuilder =
+            FormEntityBuilder.create().addParameter("cmd", "Activate").addParameter("_charset_", "utf-8").addParameter("path", nodePath).addParameter("sync", String.valueOf(true));
+        if (StringUtils.isNotBlank(agent)) {
+            formEntityBuilder.addParameter("agentId", agent);
+        }
+
+        return this.doPost("/bin/replicate.json", formEntityBuilder.build(), Collections.emptyList());
+    }
+
+    /**
+     * Checks if the given package with paths and id still in queue
+     * 
+     * @param agent the json representation retrieved
+     * @param replicatedPath path to check
+     * @param id id to check
+     * @return true if package still in queue
+     */
+    public static boolean checkPackageInQueue(Agent agent, String replicatedPath, String id) {
+        // Filter non empty queues
+        List<Queue> nonEmptyQueues = agent.getQueues().values().stream().filter(queue -> !queue.isEmpty()).collect(Collectors.toList());
+        
+        // Filter package details containing path or pkgId
+        return nonEmptyQueues.stream().anyMatch(queue -> queue.getPackageMap().values().stream().anyMatch(pkg -> {
+            boolean isIdSame = true;
+            if (isNotEmpty(id) && isNotEmpty(pkg.getPkgId())) {
+                isIdSame = pkg.getPkgId().equals(id);
+            }
+            boolean containsPkg = pkg.getPaths().contains(replicatedPath) && isIdSame;
+            if (containsPkg) {
+                log.warn("The replication queue {} contains item [id: {}, pkgId: {}] with paths {}",
+                    agent.getName(), pkg.getId(), pkg.getPkgId(), pkg.getPaths());
+            } else {
+                if (pkg.isBlocked()) {
+                    log.warn(
+                        "The replication queue {} blocked with item [id: {}, pkgId: {}] having paths {} "
+                            + "with " + "error {}", agent.getName(), pkg.getId(), pkg.getPkgId(),
+                        pkg.getPaths(), pkg.getErrorMessage());
+                }
+            }
+            return containsPkg;
+        }));
+    }
+
+    /**
+     * Checks if agent exists
+     * 
+     * @param agents the json representation retrieved
+     * @param agentName the agent
+     * @return true if agent exists
+     */
+    public static boolean checkDistributionAgentExists(Agents agents, String agentName) {
+        boolean agentPresent = agents.isAgentPresent(agentName);
+        if (!agentPresent) {
+            log.warn("Distribution agent {} is missing from the distribution list", agentName);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Checks if the given agent queue is blocked
+     * 
+     * @param agents the json representation retrieved
+     * @param agentName the agent
+     * @return true if agent blocked
+     */
+    public static boolean isAgentQueueBlocked(Agents agents, String agentName) {
+        Optional<Agent> agent = agents.getAgentBlocked(agentName);
+        return agent.isPresent();
+    }
+
+    /**
+     * Retrieve the agents from the author
+     * 
+     * @return Agents object
+     * @throws SmokeTestException if any error
+     */
+    public Agents getAgentQueueJson() throws SmokeTestException {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            SlingHttpResponse response = this.doGet(DIST_AGENTS_PATH + ".infinity.json", HttpUtils.getExpectedStatus(200));
+            return mapper.readValue(response.getContent(), Agents.class);
+        } catch (IOException | ClientException e) {
+            throw new SmokeTestException(GENERIC, "Exception getting agent queues", e);
+        }
+    }
+    
+    public ReplicationException getReplicationException(String code, String message, Throwable t) {
+        ReplicationException exception = new ReplicationException(code, message, t);
+        log.error(exception.getMessage(), t);
+        return exception;
+    }
+
+    public SmokeTestException getGenericException(String message, Throwable t) {
+        SmokeTestException exception = new SmokeTestException(GENERIC, message, t);
+        log.error(exception.getMessage(), t);
+        return exception;
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agent.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agent.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.replication.data;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Agent {
+
+    private static final String BLOCKED = "BLOCKED";
+    
+    @JsonProperty("state")
+    private String state;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("queues")
+    private Map<String, Queue> queues = new HashMap<>();
+
+    private void addQueue(String id, Queue queue) {
+        queues.put(id, queue);
+    }
+
+    public Map<String, Queue> getQueues() {
+        return queues;
+    }
+    
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    @JsonIgnore
+    public boolean isBlocked() {
+        return getState().equalsIgnoreCase(BLOCKED);
+    }
+
+    @Override 
+    public String toString() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+        }
+        return "";
+    }
+
+    public static Agent fromJson(JsonNode node) {
+        Agent agent = new Agent();
+        
+        if (node != null && !node.isMissingNode()) {
+            agent.setState(node.path("status").path("state").asText());
+            agent.setName(node.path("name").asText());
+            
+            JsonNode queuesJson = node.path("queues");
+            Iterator<JsonNode> itemsIterator = queuesJson.path("items").elements();
+
+            while (itemsIterator.hasNext()) {
+                String queue = itemsIterator.next().asText();
+                agent.addQueue(queue, Queue.fromJson(queuesJson.path(queue)));
+            }
+        }
+        return agent;
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agents.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agents.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.replication.data;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import static com.adobe.cq.cloud.testing.it.smoke.replication.data.Agents.AgentsDeserializer;
+
+@JsonDeserialize(using = AgentsDeserializer.class)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Agents {
+    @JsonProperty()
+    private Map<String, Agent> agents = new HashMap<>();
+
+    private void addAgent(String id, Agent agent) {
+        agents.put(id, agent);
+    }
+
+    public Agent getAgent(String id) {
+        return agents.get(id);
+    }
+    
+    public boolean isAgentPresent(String agent) {
+        return agents.containsKey(agent);
+    }
+    
+    public Optional<Agent> getAgentBlocked(String agentName) {
+        return agents.values().stream().filter(
+            agent -> agent.isBlocked() && agent.getName().equalsIgnoreCase(agentName)).findAny();
+    }
+    
+    @Override 
+    public String toString() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        try {
+            return mapper.writeValueAsString(agents);
+        } catch (JsonProcessingException e) {
+        }
+        return "";
+    }
+
+    public static class AgentsDeserializer extends StdDeserializer<Agents> {
+        protected AgentsDeserializer() {
+            this(null);
+        }
+        
+        protected AgentsDeserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public Agents deserialize(JsonParser jp, DeserializationContext ctx) throws IOException {
+            Agents agents = new Agents();
+            
+            JsonNode agentsNode = jp.getCodec().readTree(jp);   
+            if (agentsNode != null && !agentsNode.isMissingNode()) {
+                Iterator<JsonNode> itemsIterator = agentsNode.path("items").elements();
+
+                while (itemsIterator.hasNext()) {
+                    String agent = itemsIterator.next().asText();
+                    agents.addAgent(agent, Agent.fromJson(agentsNode.path(agent)));
+                }
+            }
+            
+            return agents;
+        }
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.replication.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Package {
+
+    private static final String ERROR = "ERROR";
+    
+    @JsonProperty("size")
+    private int size;
+
+    @JsonProperty("paths")
+    private List<String> paths = new ArrayList<>();
+
+    @JsonProperty("errorMessage")
+    private String errorMessage;
+
+    @JsonProperty("action")
+    private String action;
+   
+    @JsonProperty("id")
+    private String id;
+   
+    @JsonProperty("pkgId")
+    private String pkgId;
+   
+    @JsonProperty("time")
+    private String time;
+   
+    @JsonProperty("state")
+    private String state;
+   
+    @JsonProperty("userid")
+    private String userid;
+   
+    @JsonProperty("attempts")
+    private int attempts;
+    
+    @JsonIgnore
+    public boolean isBlocked() {
+        return state.equalsIgnoreCase(ERROR);
+    }
+    
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+    
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+    
+    public String getPkgId() {
+        return pkgId;
+    }
+
+    public void setPkgId(String pkgId) {
+        this.pkgId = pkgId;
+    }
+    
+    public String getTime() {
+        return time;
+    }
+
+    public void setTime(String time) {
+        this.time = time;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getUserid() {
+        return userid;
+    }
+
+    public void setUserid(String userid) {
+        this.userid = userid;
+    }
+
+    public int getAttempts() {
+        return attempts;
+    }
+
+    public void setAttempts(int attempts) {
+        this.attempts = attempts;
+    }
+
+    @Override
+    public String toString() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+        }
+        return "";
+    }
+    
+    public static Package fromJson(JsonNode node) {
+        Package pkg = new Package();
+        
+        if (node != null) {
+            pkg.setSize(node.path("size").asInt());
+
+            List<String> paths = new ArrayList<>();
+            for (JsonNode pathNode : node.path("paths")) {
+                paths.add(pathNode.asText());
+            }
+            pkg.setPaths(paths);
+            pkg.setAction(node.path("action").asText(""));
+            pkg.setId(node.path("id").asText(""));
+            pkg.setPkgId(node.path("pkgId").asText(""));
+            pkg.setTime(node.path("time").asText(""));
+            pkg.setState(node.path("state").asText(""));
+            pkg.setAttempts(node.path("attempts").asInt());
+            pkg.setErrorMessage(node.path("errorMessage").asText(""));
+            pkg.setUserid(node.path("userid").asText(""));
+        }
+        return pkg;
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Queue.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Queue.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.replication.data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Queue {
+    @JsonProperty
+    private String name;
+    
+    @JsonProperty("state")
+    private String state;
+    
+    @JsonProperty("itemsCount")
+    private int itemsCount;
+    
+    @JsonProperty("empty")
+    private boolean empty;
+    
+    @JsonProperty("packages")
+    private Map<String, Package> packageMap = new HashMap<>();
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+    
+    private void setPackage(String id, Package pkg) {
+        packageMap.put(id, pkg);
+    }
+
+    public Map<String, Package> getPackageMap() {
+        return packageMap;
+    }
+    
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public int getItemsCount() {
+        return itemsCount;
+    }
+
+    public void setItemsCount(Integer itemsCount) {
+        this.itemsCount = itemsCount;
+    }
+
+    public boolean isEmpty() {
+        return empty;
+    }
+
+    public void setEmpty(Boolean empty) {
+        this.empty = empty;
+    }
+
+    public static Queue fromJson(JsonNode node) {
+        Queue queue = new Queue();
+        
+        if (node != null) {
+            queue.setState(node.path("state").asText(""));
+            queue.setItemsCount(node.path("itemsCount").asInt());
+            queue.setEmpty(node.path("empty").asBoolean(true));
+
+            //Iterator<JsonNode> itemsIterator = node.path("items").elements();
+            
+            Iterator<String> fieldNames = node.fieldNames();
+            List<String> fieldList = new ArrayList<>();
+            fieldNames.forEachRemaining(fieldList::add);
+            List<String> pkgs =
+                fieldList.stream().filter(s -> s.startsWith("package")).collect(Collectors.toList());
+
+            for (String pkg : pkgs) {
+                queue.setPackage(pkg, Package.fromJson(node.path(pkg)));
+            }
+        }
+        return queue;
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/ReplicationResponse.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/ReplicationResponse.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.replication.data;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+
+import static org.apache.sling.testing.clients.util.JsonUtils.getJsonNodeFromString;
+
+/**
+ * Object to parse and store the replication response
+ */
+public class ReplicationResponse {
+    private int code;
+    private String message;
+    private String artifactId;
+
+    public static ReplicationResponse from(SlingHttpResponse response) {
+        ReplicationResponse res = new ReplicationResponse();
+        res.setCode(response.getStatusLine().getStatusCode());
+        try {
+            JsonNode jsonNode = getJsonNodeFromString(response.getContent());
+            parseJson(res, jsonNode);
+            return res;
+        } catch (ClientException e) {
+            // Switch to throwing error once json is returned
+        }
+        // Is html
+        res.setMessage(response.getContent());
+        return res;
+    }
+
+    public static void parseJson(ReplicationResponse res, JsonNode jsonNode) {
+        res.setMessage(jsonNode.path("status.message").asText());
+        JsonNode artifactId = jsonNode.path("artifactId");
+        if (!artifactId.isMissingNode()) {
+            JsonNode path = artifactId.path(0);
+            if (!path.isMissingNode()) {
+                res.setId(path.asText());
+            }
+        }
+    }
+
+    public String getMessage() {
+        return message != null ? message : "";
+    }
+
+    private void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getId() {
+        return artifactId != null ? artifactId : "";
+    }
+
+    private void setId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    private void setCode(int code) {
+        this.code = code;
+    }
+
+    @Override 
+    public String toString() {
+        return "ReplicationResponse{" + "code=" + code + ", message='" + message + '\'' + ", artifactId='" + artifactId
+            + '\'' + '}';
+    }
+}

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.rules;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.adobe.cq.cloud.testing.it.smoke.exception.SmokeTestException;
+import com.adobe.cq.cloud.testing.it.smoke.replication.ReplicationClient;
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.Agents;
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.ReplicationResponse;
+import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.rules.Page;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.apache.sling.testing.clients.util.poller.Polling;
+import org.apache.sling.testing.junit.rules.instance.Instance;
+import org.junit.AssumptionViolatedException;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.ITEM_NOT_REPLICATED;
+import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.QUEUE_BLOCKED;
+import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.REPLICATION_UNAVAILABLE;
+import static com.adobe.cq.cloud.testing.it.smoke.replication.ReplicationClient.checkPackageInQueue;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+
+/**
+ * Junit test rule to check content distribution functionality
+ */
+public class ContentPublishRule extends ExternalResource {
+    private static final Logger log = LoggerFactory.getLogger(ContentPublishRule.class);
+    
+    protected static final long TIMEOUT = TimeUnit.MINUTES.toMillis(5);
+    protected static final long TIMEOUT_PER_TRY = TimeUnit.MINUTES.toMillis(1);
+
+    protected static final String PUBLISH_DIST_AGENT = "publish";
+    
+    private final Page root;
+
+    private final Instance authorRule;
+    private final Instance publishRule;
+
+    private ReplicationClient replicationClient;
+
+    private CQClient publishClient;
+    private CQClient authorClient;
+    
+    public ContentPublishRule(Page root, Instance authorRule, Instance publishRule) {
+        this.root = root;
+        this.authorRule = authorRule;
+        this.publishRule = publishRule;
+    }
+
+    /**
+     * Initialize the replication client
+     * Assert publish agent is available
+     * Assert publish agent queues not blocked
+     * 
+     * @throws Exception if exception occurs
+     */
+    @Override
+    protected void before() throws Exception {
+        replicationClient = getAuthorClient().adaptTo(ReplicationClient.class);
+        doReplicationChecks();
+    }
+
+    /**
+     * The client to use for page operations. The default implementation creates a {@link CQClient}.
+     * The default implementation also uses the default admin user.
+     *
+     * @return The client to use for page operations.
+     */
+    protected CQClient getPublishClient() {
+        if (publishClient == null) {
+            publishClient = publishRule.getAdminClient(CQClient.class);
+        }
+        return publishClient;
+    }
+
+    /**
+     * The author client to use for page operations. The default implementation creates a {@link CQClient}.
+     * The default implementation also uses the default admin user.
+     *
+     * @return The client to use for page operations.
+     */
+    protected CQClient getAuthorClient() {
+        if (authorClient == null) {
+            authorClient =  authorRule.getAdminClient(CQClient.class);
+        }
+        return authorClient;
+    }
+    
+    /**
+     * Checks that a GET on the page on publish has the {{expectedStatus}} in the response
+     *
+     * @throws Exception if an error occurred
+     */
+    private void checkPage(final int...  expectedStatus) throws Exception {
+        final String path = root.getPath() + ".html";
+        log.info("Checking page {} returns status {}", getPublishClient().getUrl(path), expectedStatus);
+        SlingHttpResponse res;
+        final List<NameValuePair> queryParams = Collections.singletonList(
+            new BasicNameValuePair("timestamp", String.valueOf(System.currentTimeMillis())));
+
+        res = getPublishClient().doGet(path, queryParams, Collections.emptyList());
+        if (null != res && res.getStatusLine().getStatusCode() == SC_UNAUTHORIZED) {
+            throw new AssumptionViolatedException("Publish requires auth for (SAML?). Skipping...");
+        }
+
+        try {
+            new Polling() {
+                @Override public Boolean call() throws Exception {
+                    final List<NameValuePair> queryParams = Collections.singletonList(
+                            new BasicNameValuePair("timestamp", String.valueOf(System.currentTimeMillis())));
+                    getPublishClient().doGet(path, queryParams, Collections.emptyList(), expectedStatus);
+                    return true;
+                }
+            }.poll(TIMEOUT_PER_TRY, 1000);
+        } catch (TimeoutException te) {
+            log.warn("Failed to check the page {} via the AEM publish ingress (expected status {}). Please ensure that the CDN and Dispatcher configurations allow fetching the page.", root.getPath(), expectedStatus);
+            throw te;
+        }
+    }
+    
+    public void activateAssertPublish() throws Exception {
+        // Activate Page
+        ReplicationResponse replicationResponse = replicationClient.activate(root.getPath());
+
+        // Check activation successful
+        waitPublishQueueEmptyOfPath(replicationResponse.getId(), root.getPath(), "Activate");
+        
+        // Assert page added on publish
+        checkPage(SC_OK);
+    }
+
+    public void deactivateAssertPublish() throws Exception {
+        // Deactivate Page
+        ReplicationResponse replicationResponse = replicationClient.deactivate(root.getPath());
+        
+        // Check deactivation successful
+        waitPublishQueueEmptyOfPath(replicationResponse.getId(), root.getPath(), "Deactivate");
+        
+        // Assert page deleted on publish
+        checkPage(SC_NOT_FOUND);
+    }
+    
+    private void waitPublishQueueEmptyOfPath(String id, String path, String action)
+        throws SmokeTestException {
+       waitQueueEmptyOfPath(PUBLISH_DIST_AGENT, path, id, action);
+    }
+
+    /**
+     * Checks presence of publish distribution agent and waits until timeout if it's available
+     * Checks if the publish agent is not blocked
+     * 
+     * @throws SmokeTestException exception if problems
+     */
+    private void doReplicationChecks() throws SmokeTestException {
+        Polling polling = null;
+        AtomicReference<Agents> agentsRef = new AtomicReference<>();
+
+        log.info("Checking Replication agents available and not blocked");
+
+        // Check if the publish agent is present and retry till timeout
+        try {
+            polling = new Polling(() -> {
+                agentsRef.set(replicationClient.getAgentQueueJson());
+                log.info("Replication agents list: {}", agentsRef.get());
+
+                return ReplicationClient.checkDistributionAgentExists(agentsRef.get(), PUBLISH_DIST_AGENT);
+            });
+            polling.poll(TIMEOUT, 500);
+        } catch (TimeoutException e) {
+            throw replicationClient.getReplicationException(REPLICATION_UNAVAILABLE, 
+                String.format("Replication agent %s unavailable", PUBLISH_DIST_AGENT), polling.getLastException());
+        } catch (Exception e) {
+            throw replicationClient.getGenericException("Replication agent unavailable", e);
+        }
+
+        Agents agents = agentsRef.get();
+        
+        // throw if publish agent is blocked
+        boolean agentQueueBlocked = ReplicationClient.isAgentQueueBlocked(agents, PUBLISH_DIST_AGENT);
+        if (agentQueueBlocked) {
+            throw replicationClient.getReplicationException(QUEUE_BLOCKED, 
+                "Replication agent queue blocked - " + agents.getAgent(PUBLISH_DIST_AGENT), null);
+        }
+    }
+    
+    /**
+     * Checks if the agent queue contains the given id and the path until timeout.
+     *
+     * @param agent   queue to check
+     * @param path    path being replicated
+     * @param id      identifier for the replication request
+     * @param action  the action initiated Activate or Deactivate
+     * @throws SmokeTestException exception containing error details if any
+     */
+    public void waitQueueEmptyOfPath(final String agent, final String path, final String id, final String action)
+        throws SmokeTestException {
+        Polling polling = null;
+        AtomicReference<Agents> agentsRef = new AtomicReference<>();
+        
+        log.info("Checking the replication queue [{}] for action [{}] contains item [pkgId: {}] with paths [{}]",
+            agent, action, id, path);
+        
+        // Check if the agent has the package
+        try {
+            polling = new Polling(() -> {
+                agentsRef.set(replicationClient.getAgentQueueJson());
+                return !checkPackageInQueue(agentsRef.get().getAgent(agent), path, id);
+            });
+            polling.poll(TIMEOUT, 2000);
+        } catch (TimeoutException e) {
+            log.info("Agent not empty of item {}", ((agentsRef.get() != null) ? agentsRef.get().getAgent(agent) : ""));
+            throw replicationClient.getReplicationException(ITEM_NOT_REPLICATED, 
+                String.format("Item not activated within %s ms", TIMEOUT),
+                polling.getLastException());
+        } catch (Exception e) {
+            throw replicationClient.getGenericException(String.format("Item not activated within %s ms", TIMEOUT), e);
+        }
+    }
+}
+

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -153,7 +153,7 @@ public class ContentPublishRule extends ExternalResource {
             
             res  = getPublishClient().doStreamRequest(request, null);
             
-            // Special handling for 401,403,301,302
+            // Special handling for 401,403, logging for 301,302
             if (null != res && (res.getStatusLine().getStatusCode() == SC_UNAUTHORIZED
                 || res.getStatusLine().getStatusCode() == SC_FORBIDDEN)) {
                 log.warn("Got status {} while checking page, expected status {}", res.getStatusLine().getStatusCode(),
@@ -161,9 +161,7 @@ public class ContentPublishRule extends ExternalResource {
                 throw new AssumptionViolatedException("Publish requires auth for (SAML?) or not authorized. Skipping...");
             } else if (null != res && (res.getStatusLine().getStatusCode() == SC_MOVED_PERMANENTLY 
                 || res.getStatusLine().getStatusCode() == SC_MOVED_TEMPORARILY)) {
-                log.warn("Got status {} while checking page, expected status {}", res.getStatusLine().getStatusCode(),
-                    expectedStatus);
-                throw new AssumptionViolatedException(String.format("Publish %s configured for redirect", path));
+                log.info("Redirect status {} detected for page {}", res.getStatusLine().getStatusCode(), path);
             } else if (null != res && (res.getStatusLine().getStatusCode() == expectedStatus)) {
                 log.info("Page check completed with status {}", res.getStatusLine().getStatusCode());
                 return;

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -45,9 +45,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.adobe.cq.cloud.testing.it.smoke.exception.PublishException.getPageErrorCode;
-import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.ITEM_NOT_REPLICATED;
+import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.ACTION_NOT_REPLICATED;
 import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.QUEUE_BLOCKED;
-import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.REPLICATION_UNAVAILABLE;
+import static com.adobe.cq.cloud.testing.it.smoke.exception.ReplicationException.REPLICATION_NOT_AVAILABLE;
 import static com.adobe.cq.cloud.testing.it.smoke.replication.ReplicationClient.checkPackageInQueue;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_MOVED_PERMANENTLY;
@@ -246,7 +246,7 @@ public class ContentPublishRule extends ExternalResource {
             });
             polling.poll(TIMEOUT, 500);
         } catch (TimeoutException e) {
-            throw replicationClient.getReplicationException(REPLICATION_UNAVAILABLE, 
+            throw replicationClient.getReplicationException(REPLICATION_NOT_AVAILABLE, 
                 String.format("Replication agent %s unavailable", PUBLISH_DIST_AGENT), polling.getLastException());
         } catch (Exception e) {
             throw replicationClient.getGenericException("Replication agent unavailable", e);
@@ -288,7 +288,7 @@ public class ContentPublishRule extends ExternalResource {
             polling.poll(TIMEOUT, 2000);
         } catch (TimeoutException e) {
             log.info("Agent not empty of item {}", ((agentsRef.get() != null) ? agentsRef.get().getAgent(agent) : ""));
-            throw replicationClient.getReplicationException(ITEM_NOT_REPLICATED, 
+            throw replicationClient.getReplicationException(ACTION_NOT_REPLICATED, 
                 String.format("Item not activated within %s ms", TIMEOUT),
                 polling.getLastException());
         } catch (Exception e) {

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adobe.cq.cloud.testing.it.smoke.rules;
+
+import java.io.IOException;
+
+import com.adobe.cq.cloud.testing.it.smoke.exception.ServiceException;
+import com.adobe.cq.testing.client.CQClient;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.apache.sling.testing.junit.rules.instance.Instance;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.adobe.cq.cloud.testing.it.smoke.exception.ServiceException.SUFFIX;
+
+/**
+ * Junit test rule to check service up
+ */
+public class ServiceAccessibleRule implements TestRule {
+    private static final Logger log = LoggerFactory.getLogger(ServiceAccessibleRule.class);
+    
+    public static final String SYSTEM_READY = "systemready";
+    
+    private final Instance instance;
+    private final String runmode;
+    private final CQClient adminClient;
+
+    public ServiceAccessibleRule(Instance instance) {
+        this.instance = instance;
+        this.runmode = instance.getConfiguration().getRunmode();
+        this.adminClient = instance.getAdminClient(CQClient.class);
+    }
+
+    public Statement apply(Statement base, Description description) {
+        try {
+            HttpClient client = HttpClientBuilder.create().build();
+            HttpResponse httpResponse = client.execute(new HttpGet(adminClient.getUrl(SYSTEM_READY)));
+            int status = httpResponse.getStatusLine().getStatusCode();
+            String response = EntityUtils.toString(httpResponse.getEntity());
+            if (status != 200) {
+                throw new IOException(String.format("Status Code - %s, response - %s", status, response));
+            }
+            log.info("Health check for {} passed - {}", runmode.toUpperCase(), response);
+        } catch (Exception ce) {
+            ServiceException serviceException = new ServiceException(runmode.toUpperCase() + SUFFIX, ce.getMessage());
+            log.info("Health check failure", serviceException);
+            // TODO throw exceptions once the instance health check URLs GA
+            //throw serviceException;
+        }
+        return base;
+    }
+}

--- a/smoke/src/test/java/AgentsTest.java
+++ b/smoke/src/test/java/AgentsTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2022 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.Agent;
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.Agents;
+import com.adobe.cq.cloud.testing.it.smoke.replication.data.ReplicationResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.Test;
+
+import static com.adobe.cq.cloud.testing.it.smoke.replication.ReplicationClient.checkDistributionAgentExists;
+import static com.adobe.cq.cloud.testing.it.smoke.replication.ReplicationClient.checkPackageInQueue;
+import static com.adobe.cq.cloud.testing.it.smoke.replication.ReplicationClient.isAgentQueueBlocked;
+import static com.adobe.cq.cloud.testing.it.smoke.replication.data.ReplicationResponse.parseJson;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the various data objects for json parsed methods
+ */
+public class AgentsTest {
+    
+    @Test
+    public void runningIncompleteQueueState() throws IOException {
+        String json =
+            "{\n" + "  \"sling:resourceType\": \"sling/distribution/service/agent/list\",\n" + "  \"items\": [\n" + 
+                "    \"preview\",\n" + "    \"publish\"\n" + "  ],\n" + "  \"preview\": {\n"
+                + "    \"name\": \"preview\",\n" + "    \"sling:resourceType\": \"sling/distribution/service/agent\",\n"
+                + "    \"queues\": {\n" + "      \"sling:resourceType\": \"sling/distribution/service/agent/queue"
+                + "/list\",\n" + "      \"items\": [\n" + "        \"6f079cc9-18fe-4168-b6dc-121436c356ee-previewSubscriber\",\n"
+                + "        \"770c893c-60ee-47de-a9b0-ad985addbfea-previewSubscriber\"\n" + "      ],\n"
+                + "      \"6f079cc9-18fe-4168-b6dc-121436c356ee-previewSubscriber\": {\n" + "        \"capabilities" 
+                + "\": [],\n"
+                + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n" + "        \"state" 
+                + "\": \"IDLE\",\n" + "        \"items\": [],\n" + "        \"itemsCount\": 0,\n"
+                + "        \"empty\": true\n" + "      },\n" + "      \"770c893c-60ee-47de-a9b0-ad985addbfea-previewSubscriber\": {\n"
+                + "        \"capabilities\": [\n" + "          \"removable\",\n" + "          \"clearable\"\n" + "   "
+                + "     ],\n" + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n" + 
+                "        \"state\": \"IDLE\",\n" + "        \"items\": [],\n" + "        \"itemsCount\": 0,\n"
+                + "        \"empty\": true\n" + "      }\n" + "    },\n" + "    \"log\": {\n" + "      \"sling"
+                + ":resourceType\": \"sling/distribution/service/log\"\n" + "    },\n" + "    \"status\": {\n" + 
+                "      \"state\": \"IDLE\"\n" + "    }\n" + "  },\n" + "  \"publish\": {\n"
+                + "    \"name\": \"publish\",\n" + "    \"sling:resourceType\": \"sling/distribution/service/agent\",\n"
+                + "    \"queues\": {\n"
+                + "      \"sling:resourceType\": \"sling/distribution/service/agent/queue/list\",\n"
+                + "      \"items\": [\n" + "        \"3b091547-e734-4a0d-9558-9fb198a52a6b-publishSubscriber\",\n"
+                + "        \"27756db5-7160-41d7-bb46-595f82ad0558-publishSubscriber\",\n"
+                + "        \"efb9696b-135a-4fe4-81fb-37d867a77826-publishSubscriber\"\n" + "      ],\n"
+                + "      \"3b091547-e734-4a0d-9558-9fb198a52a6b-publishSubscriber\": {\n"
+                + "        \"capabilities\": [],\n" + "        \"sling:resourceType\": \"sling/distribution/service"
+                + "/agent/queue\",\n" + "        \"state\": \"RUNNING\",\n" + "        \"items\": [\n" + 
+                "          \"package-0@1918741\"\n"
+                + "        ],\n" + "        \"itemsCount\": 3,\n" + "        \"empty\": false\n" + "      },\n"
+                + "      \"27756db5-7160-41d7-bb46-595f82ad0558-publishSubscriber\": {\n" + "        \"capabilities"
+                + "\": [\n" + "          \"removable\",\n" + "          \"clearable\"\n" + "        ],\n"
+                + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n"
+                + "        \"state\": \"RUNNING\",\n" + "        \"items\": [\n" + "          \"package-0@1918741\"\n" + "        ],\n" + "        \"itemsCount\": 3,\n" + "        \"empty\": false\n" + "      },\n"
+                + "      \"efb9696b-135a-4fe4-81fb-37d867a77826-publishSubscriber\": {\n" + 
+                "        \"capabilities\": [],\n"
+                + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n" + "        \"state"
+                + "\": \"RUNNING\",\n" + "        \"items\": [\n" + "          \"package-0@1918741\"\n" + "        ],\n"
+                + "        \"itemsCount\": 3,\n" + "        \"empty\": false\n" + "      }\n" + "   " + " },\n"
+                + "    \"log\": {\n" + "      \"sling:resourceType\": \"sling/distribution/service/log\"\n" + "    },\n"
+                + "    \"status\": {\n" + "      \"state\": \"RUNNING\"\n" + "    }\n" + "  }\n" + "}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        Agents agents = mapper.readValue(json, Agents.class);
+        assertTrue(checkDistributionAgentExists(agents,"publish"));
+        assertTrue(checkDistributionAgentExists(agents, "preview"));
+        assertFalse(isAgentQueueBlocked(agents, "publish"));
+
+        Agent publish = agents.getAgent("publish");
+        assertNotNull(publish);
+
+        assertFalse(checkPackageInQueue(publish, "/content/dam/test/atari65xe_desc.html",
+            "dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6"));
+        assertFalse(checkPackageInQueue(publish, "/content/dam/test/atari65xe_desc.html",
+            ""));
+        assertFalse(checkPackageInQueue(publish, "",
+            "dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6"));
+    }
+    
+    @Test
+    public void blockedRunningQueueState() throws IOException {
+        String json =
+            "{\n" + "  \"sling:resourceType\": \"sling/distribution/service/agent/list\",\n" + "  \"items\": [\n" + 
+                "    \"publish\"\n" + "  ],\n" + "  \"publish\": {\n"
+                + "    \"name\": \"publish\",\n" + "    \"sling:resourceType\": \"sling/distribution/service/agent\",\n"
+                + "    \"queues\": {\n" + 
+                "      \"sling:resourceType\": \"sling/distribution/service/agent/queue/list\",\n"
+                + "      \"items\": [\n" + "        \"31671be6-39fe-4841-8bfc-0246b44b6930-publishSubscriber\",\n" + "        \"546aa35f-1eb0-462d-aacf-ea227d35d28e-publishSubscriber\"\n" + "      ],\n"
+                + "      \"31671be6-39fe-4841-8bfc-0246b44b6930-publishSubscriber\": {\n" + "        \"capabilities\": [\n"
+                + "          \"removable\",\n" + "          \"clearable\"\n" + "        ],\n" + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n"
+                + "        \"state\": \"RUNNING\",\n" + "        \"items\": [\n" + "          \"package-0@58870963\"\n"
+                + "        ],\n" + "        \"itemsCount\": 1,\n" + "        \"empty\": false,\n" + 
+                "        \"package-0@58870963\": {\n" + "          \"size\": 7794,\n" + "          \"paths\": [\n"
+                + "            \"/content/dam/test/atari65xe_desc.html\"\n" + "          ],\n" + "          \"sling" 
+                + ":resourceType\": \"sling/distribution/service/agent/queue/item\",\n"
+                + "          \"action\": \"ADD\",\n" + "          \"id\": \"package-0@58870963\",\n" + "          " 
+                + "\"pkgId\": \"dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6\",\n"
+                + "          \"time\": \"Fri Feb 18 09:13:56 UTC 2022\",\n" + "          \"state\": \"QUEUED\",\n" + 
+                "          \"userid\": \"replication-service\",\n" + "          \"attempts\": 0\n" + "        }\n"
+                + "      },\n" + "      \"546aa35f-1eb0-462d-aacf-ea227d35d28e-publishSubscriber\": {\n" + "        " 
+                + "\"capabilities\": [],\n"
+                + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n" + "        \"state\": \"BLOCKED\",\n" + "        \"items\": [\n" + "          \"package-0@58870963\"\n"
+                + "        ],\n" + "        \"itemsCount\": 1,\n" + "        \"empty\": false,\n" + "        " 
+                + "\"package-0@58870963\": {\n" + "          \"size\": 7794,\n" + "          \"paths\": [\n"
+                + "            \"/content/dam/test/atari65xe8_desc.html\"\n" + "          ],\n" + "          \"errorMessage\": \"Failed attempt (12/infinite) to import the distribution package\",\n"
+                + "          \"sling:resourceType\": \"sling/distribution/service/agent/queue/item\",\n" + 
+                "          \"action\": \"ADD\",\n" + "          \"id\": \"package-0@58870963\",\n"
+                + "          \"pkgId\": \"dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e8\",\n" + 
+                "          \"time\": \"Fri Feb 18 09:13:56 UTC 2022\",\n" + "          \"state\": \"ERROR\",\n"
+                + "          \"userid\": \"replication-service\",\n" + "          \"attempts\": 0\n" + "        }\n" + "      }\n" + "    },\n" + "    \"log\": {\n"
+                + "      \"sling:resourceType\": \"sling/distribution/service/log\"\n" + "    },\n" + "    \"status\": {\n"
+                + "      \"state\": \"BLOCKED\"\n" + "    }\n" + "  }\n" + "}";
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        Agents agents = mapper.readValue(json, Agents.class);
+
+        assertTrue(checkDistributionAgentExists(agents,"publish"));
+        assertFalse(checkDistributionAgentExists(agents, "preview"));
+        assertTrue(isAgentQueueBlocked(agents, "publish"));
+
+        Agent publish = agents.getAgent("publish");
+        assertNotNull(publish);
+        
+        assertTrue(checkPackageInQueue(publish, "/content/dam/test/atari65xe_desc.html", 
+            "dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6"));
+        assertTrue(checkPackageInQueue(publish, "/content/dam/test/atari65xe_desc.html",
+            ""));
+    }
+    
+    @Test
+    public void runningQueueState() throws IOException {
+        String json =
+            "{\n" + "  \"sling:resourceType\": \"sling/distribution/service/agent/list\",\n" + "  \"items\": [\n" + 
+                "    \"publish\"\n" + "  ],\n" + "  \"publish\": {\n"
+                + "    \"name\": \"publish\",\n" + "    \"sling:resourceType\": \"sling/distribution/service/agent\",\n"
+                + "    \"queues\": {\n" + 
+                "      \"sling:resourceType\": \"sling/distribution/service/agent/queue/list\",\n"
+                + "      \"items\": [\n" + "        \"31671be6-39fe-4841-8bfc-0246b44b6930-publishSubscriber\",\n" + "        \"546aa35f-1eb0-462d-aacf-ea227d35d28e-publishSubscriber\"\n" + "      ],\n"
+                + "      \"31671be6-39fe-4841-8bfc-0246b44b6930-publishSubscriber\": {\n" + "        \"capabilities\": [\n"
+                + "          \"removable\",\n" + "          \"clearable\"\n" + "        ],\n" + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n"
+                + "        \"state\": \"RUNNING\",\n" + "        \"items\": [\n" + "          \"package-0@58870963\"\n"
+                + "        ],\n" + "        \"itemsCount\": 1,\n" + "        \"empty\": false,\n" + 
+                "        \"package-0@58870963\": {\n" + "          \"size\": 7794,\n" + "          \"paths\": [\n"
+                + "            \"/content/dam/test/atari65xe_desc.html\"\n" + "          ],\n" + "          \"sling" 
+                + ":resourceType\": \"sling/distribution/service/agent/queue/item\",\n"
+                + "          \"action\": \"ADD\",\n" + "          \"id\": \"package-0@58870963\",\n" + "          " 
+                + "\"pkgId\": \"dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6\",\n"
+                + "          \"time\": \"Fri Feb 18 09:13:56 UTC 2022\",\n" + "          \"state\": \"QUEUED\",\n" + 
+                "          \"userid\": \"replication-service\",\n" + "          \"attempts\": 0\n" + "        }\n"
+                + "      },\n" + "      \"546aa35f-1eb0-462d-aacf-ea227d35d28e-publishSubscriber\": {\n" + "        " 
+                + "\"capabilities\": [],\n"
+                + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n" + "        \"state\": \"RUNNING\",\n" + "        \"items\": [\n" + "          \"package-0@58870963\"\n"
+                + "        ],\n" + "        \"itemsCount\": 1,\n" + "        \"empty\": false,\n" + "        " 
+                + "\"package-0@58870963\": {\n" + "          \"size\": 7794,\n" + "          \"paths\": [\n"
+                + "            \"/content/dam/test/atari65xe_desc.html\"\n" + "          ],\n" + "          \"sling:resourceType\": \"sling/distribution/service/agent/queue/item\",\n"
+                + "          \"action\": \"ADD\",\n" + "          \"id\": \"package-0@58870963\",\n" + 
+                "          \"pkgId\": \"dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6\",\n"
+                + "          \"time\": \"Fri Feb 18 09:13:56 UTC 2022\",\n" + "          \"state\": \"QUEUED\",\n" + 
+                "          \"userid\": \"replication-service\",\n" + "          \"attempts\": 0\n" + "        }\n"
+                + "      }\n" + "    },\n" + "    \"log\": {\n" + "      \"sling:resourceType\": \"sling/distribution/service/log\"\n" + "    },\n"
+                + "    \"status\": {\n" + "      \"state\": \"RUNNING\"\n" + "    }\n" + "  }\n" + "}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        Agents agents = mapper.readValue(json, Agents.class);
+        assertTrue(checkDistributionAgentExists(agents,"publish"));
+        assertFalse(checkDistributionAgentExists(agents, "preview"));
+        assertFalse(isAgentQueueBlocked(agents, "publish"));
+
+        Agent publish = agents.getAgent("publish");
+        assertNotNull(publish);
+        
+        assertTrue(checkPackageInQueue(publish, "/content/dam/test/atari65xe_desc.html",
+            "dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6"));
+        assertTrue(checkPackageInQueue(publish, "/content/dam/test/atari65xe_desc.html",
+            ""));
+    }
+    
+    @Test
+    public void blockedQueueState() throws IOException {
+        String json = "{\n" + "  \"sling:resourceType\": \"sling/distribution/service/agent/list\",\n"
+            + "  \"items\": [\n" + "    \"publish\"\n" + "  ],\n" + "  \"publish\": {\n"
+            + "    \"name\": \"publish\",\n" + "    \"sling:resourceType\": \"sling/distribution/service/agent\",\n"
+            + "    \"queues\": {\n" + "      \"sling:resourceType\": \"sling/distribution/service/agent/queue/list\",\n"
+            + "      \"items\": [\n" + "        \"546aa35f-1eb0-462d-aacf-ea227d35d28e-publishSubscriber\"\n"
+            + "      ],\n" + "      \"546aa35f-1eb0-462d-aacf-ea227d35d28e-publishSubscriber\": {\n"
+            + "        \"capabilities\": [],\n"
+            + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n"
+            + "        \"state\": \"BLOCKED\",\n" + "        \"items\": [\n" + "          \"package-0@58870963\"\n"
+            + "        ],\n" + "        \"itemsCount\": 1,\n" + "        \"empty\": false,\n"
+            + "        \"package-0@58870963\": {\n" + "          \"size\": 7794,\n" + "          \"paths\": [\n"
+            + "            \"/content/dam/test/atari65xe8_desc.html\"\n" + "          ],\n"
+            + "          \"errorMessage\": \"Failed attempt (12/infinite) to import the distribution package\",\n"
+            + "          \"sling:resourceType\": \"sling/distribution/service/agent/queue/item\",\n"
+            + "          \"action\": \"ADD\",\n" + "          \"id\": \"package-0@58870963\",\n"
+            + "          \"pkgId\": \"dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e68\",\n"
+            + "          \"time\": \"Fri Feb 18 09:13:56 UTC 2022\",\n" + "          \"state\": \"ERROR\",\n"
+            + "          \"userid\": \"replication-service\",\n" + "          \"attempts\": 0\n" + "        }\n"
+            + "      }\n" + "    },\n" + "    \"log\": {\n"
+            + "      \"sling:resourceType\": \"sling/distribution/service/log\"\n" + "    },\n" + "    \"status\": {\n"
+            + "      \"state\": \"BLOCKED\"\n" + "    }\n" + "  }\n" + "}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        Agents agents = mapper.readValue(json, Agents.class);
+        assertTrue(checkDistributionAgentExists(agents,"publish"));
+        assertFalse(checkDistributionAgentExists(agents, "preview"));
+        assertTrue(isAgentQueueBlocked(agents, "publish"));
+
+        Agent publish = agents.getAgent("publish");
+        assertNotNull(publish);
+
+        assertFalse(checkPackageInQueue(publish, "/content/dam/test/atari65xe_desc.html",
+            "dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6"));
+        assertFalse(checkPackageInQueue(publish, "/content/dam/test/atari65xe_desc.html",
+            ""));
+        assertFalse(checkPackageInQueue(publish, "",
+            "dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6"));
+    }
+    
+    @Test
+    public void blockedIncompleteState() throws IOException {
+        String json = "{\n" + "  \"sling:resourceType\": \"sling/distribution/service/agent/list\",\n"
+            + "  \"items\": [\n" + "    \"publish\"\n" + "  ],\n" + "  \"publish\": {\n"
+            + "    \"name\": \"publish\",\n" + "    \"queues\": {\n" + "      \"items\": [\n"
+            + "        \"7ece8e2c-d641-4d50-a0ff-6fcd3c52f7d8-publishSubscriber\",\n"
+            + "        \"0c77809c-cb61-437b-981b-0424c042fd92-publishSubscriber\"\n" + "      ],\n"
+            + "      \"7ece8e2c-d641-4d50-a0ff-6fcd3c52f7d8-publishSubscriber\": {\n"
+            + "        \"state\": \"BLOCKED\",\n" + "        \"items\": [\n" + "          \"package-0@52734825\"\n"
+            + "        ],\n" + "        \"itemsCount\": 1,\n" + "        \"empty\": false,\n"
+            + "        \"package-0@52734825\": {\n" + "          \"size\": 6073,\n" + "          \"paths\": [\n"
+            + "            \"/content/test-site/testpage_8e57dec8-40e8-4e42-a267-ff5142f5c472\"\n" + "          ],\n"
+            + "          \"errorMessage\": \"Failed attempt (12/infinite) to import the distribution package\"\n"
+            + "        }\n" + "      },\n" + "      \"0c77809c-cb61-437b-981b-0424c042fd92-publishSubscriber\": {\n"
+            + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n"
+            + "        \"state\": \"IDLE\",\n" + "        \"items\": [],\n" + "        \"itemsCount\": 0,\n"
+            + "        \"empty\": true\n" + "      }\n" + "    },\n" + "    \"log\": {\n"
+            + "      \"sling:resourceType\": \"sling/distribution/service/log\"\n" + "    },\n" + "    \"status\": {\n"
+            + "      \"state\": \"BLOCKED\"\n" + "    }\n" + "  }\n" + "}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        Agents agents = mapper.readValue(json, Agents.class);
+        assertTrue(checkDistributionAgentExists(agents,"publish"));
+        assertFalse(checkDistributionAgentExists(agents, "preview"));
+        assertTrue(isAgentQueueBlocked(agents, "publish"));
+
+        Agent publish = agents.getAgent("publish");
+        assertNotNull(publish);
+
+        assertTrue(checkPackageInQueue(publish, "/content/test-site/testpage_8e57dec8-40e8-4e42-a267-ff5142f5c472",
+            "dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6"));
+        assertTrue(checkPackageInQueue(publish, "/content/test-site/testpage_8e57dec8-40e8-4e42-a267-ff5142f5c472",
+            ""));
+        assertFalse(checkPackageInQueue(publish, "",
+            "dstrpck-1645175636103-79265f3c-779c-4f97-b572-4c81161494e6"));
+    }
+    
+    @Test
+    public void multiplePkgQueueState() throws IOException {
+        String json = "{\n" + "  \"sling:resourceType\": \"sling/distribution/service/agent/list\",\n"
+            + "  \"items\": [\n" + "    \"publish\"\n" + "  ],\n" + "  \"publish\": {\n"
+            + "    \"name\": \"publish\",\n" + "    \"sling:resourceType\": \"sling/distribution/service/agent\",\n"
+            + "    \"queues\": {\n" + "      \"sling:resourceType\": \"sling/distribution/service/agent/queue/list\",\n"
+            + "      \"items\": [\n" + "        \"c4503674-aae8-4c38-aecb-7658adc41b24-publishSubscriber\"\n"
+            + "      ],\n" + "      \"c4503674-aae8-4c38-aecb-7658adc41b24-publishSubscriber\": {\n"
+            + "        \"capabilities\": [],\n"
+            + "        \"sling:resourceType\": \"sling/distribution/service/agent/queue\",\n"
+            + "        \"state\": \"RUNNING\",\n" + "        \"items\": [\n" + "          \"package-0@58932264\"\n"
+            + "        ],\n" + "        \"itemsCount\": 3,\n" + "        \"empty\": false,\n"
+            + "        \"package-0@58932264\": {\n" + "          \"size\": 0,\n" + "          \"paths\": [\n"
+            + "            \"/content/test-site/testpage_14b07d0c-555f-415a-b1ad-ac7536ea09e2\"\n" + "          ],\n"
+            + "          \"sling:resourceType\": \"sling/distribution/service/agent/queue/item\",\n"
+            + "          \"action\": \"DELETE\",\n" + "          \"id\": \"package-0@58932264\",\n"
+            + "          \"pkgId\": \"54e829af-c99b-4b9c-86ba-3d7f97eb4e0e\",\n"
+            + "          \"time\": \"Fri Feb 25 16:16:50 UTC 2022\",\n" + "          \"state\": \"QUEUED\",\n"
+            + "          \"userid\": \"replication-service\",\n" + "          \"attempts\": 0\n" + "        },\n"
+            + "        \"package-0@58932265\": {\n" + "          \"size\": 6443,\n" + "          \"paths\": [\n"
+            + "            \"/content/test-site/testpage_14b07d0c-555f-415a-b1ad-ac7536ea09e2\"\n" + "          ],\n"
+            + "          \"sling:resourceType\": \"sling/distribution/service/agent/queue/item\",\n"
+            + "          \"action\": \"ADD\",\n" + "          \"id\": \"package-0@58932265\",\n"
+            + "          \"pkgId\": \"dstrpck-1645805891362-264d77b5-d5cd-4138-8632-6d613fd2b3f6\",\n"
+            + "          \"time\": \"Fri Feb 25 16:18:11 UTC 2022\",\n" + "          \"state\": \"QUEUED\",\n"
+            + "          \"userid\": \"replication-service\",\n" + "          \"attempts\": 0\n" + "        },\n"
+            + "        \"package-0@58932266\": {\n" + "          \"size\": 0,\n" + "          \"paths\": [\n"
+            + "            \"/content/test-site/testpage_14b07d0c-555f-415a-b1ad-ac7536ea09e2\"\n" + "          ],\n"
+            + "          \"sling:resourceType\": \"sling/distribution/service/agent/queue/item\",\n"
+            + "          \"action\": \"DELETE\",\n" + "          \"id\": \"package-0@58932266\",\n"
+            + "          \"pkgId\": \"225635ae-c74b-4eb0-ae6a-d01f68c4c960\",\n"
+            + "          \"time\": \"Fri Feb 25 16:19:12 UTC 2022\",\n" + "          \"state\": \"QUEUED\",\n"
+            + "          \"userid\": \"replication-service\",\n" + "          \"attempts\": 0\n" + "        }\n"
+            + "      }\n" + "    },\n" + "    \"log\": {\n"
+            + "      \"sling:resourceType\": \"sling/distribution/service/log\"\n" + "    },\n" + "    \"status\": {\n"
+            + "      \"state\": \"RUNNING\"\n" + "    }\n" + "  }\n" + "}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        Agents agents = mapper.readValue(json, Agents.class);
+        assertTrue(checkDistributionAgentExists(agents,"publish"));
+        assertFalse(checkDistributionAgentExists(agents, "preview"));
+        assertFalse(isAgentQueueBlocked(agents, "publish"));
+
+        Agent publish = agents.getAgent("publish");
+        assertNotNull(publish);
+
+        assertTrue(checkPackageInQueue(publish, "/content/test-site/testpage_14b07d0c-555f-415a-b1ad-ac7536ea09e2",
+            "dstrpck-1645805891362-264d77b5-d5cd-4138-8632-6d613fd2b3f6"));
+        assertTrue(checkPackageInQueue(publish, "/content/test-site/testpage_14b07d0c-555f-415a-b1ad-ac7536ea09e2",
+            "dstrpck-1645805891362-264d77b5-d5cd-4138-8632-6d613fd2b3f6"));
+    }
+    
+    @Test
+    public void responseTest() throws IOException {
+        String json = "{\n" + "  \"path\": [\n" + "    \"/content/dam/test/atari65xe_desc.html\"\n" + "  ],\n"
+            + "  \"artifactId\": [\n" + "    \"dstrpck-1645087114730-810bc013-2c41-447e-9714-f288b0e63080\"\n"
+            + "  ],\n" + "  \"status.message\": \"Replication started for /content/dam/test/atari65xe_desc.html\",\n"
+            + "  \"status.code\": 200\n" + "}";
+        ReplicationResponse res = new ReplicationResponse();
+        ObjectMapper mapper = new ObjectMapper();
+        parseJson(res, mapper.readTree(json));
+        assertEquals("dstrpck-1645087114730-810bc013-2c41-447e-9714-f288b0e63080", res.getId());
+        assertEquals("Replication started for /content/dam/test/atari65xe_desc.html", res.getMessage());
+    }
+}


### PR DESCRIPTION
## Description

- Rename ReplicationIT -> PublishEndToEndIT
- Remove #activateAndDelete test
- Add Replication pre-checks and also check replication queue to check after test
- Add Service Up/Down pre-checks
- Introduce appropriate Exceptions and error codes to help to classify the failures if any

## Related Issue

https://github.com/adobe/aem-test-samples/issues/32

## Motivation and Context

The current ReplicationIT is an actual end to end test but the name suggests that the responsibility of the failure is for 1 component only. But that is not true as the assertions on presence/absence of a page for ADD/DELETE case relies on the page being accessible through the dispatcher and publish.

## How Has This Been Tested?

Changes tested on a cloud environment

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
