### PR TITLE
Remove newlines from messages logged and retry service up

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agent.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agent.java
@@ -74,7 +74,6 @@ public class Agent {
     @Override 
     public String toString() {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.enable(SerializationFeature.INDENT_OUTPUT);
 
         try {
             return mapper.writeValueAsString(this);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agents.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agents.java
@@ -62,7 +62,6 @@ public class Agents {
     @Override 
     public String toString() {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.enable(SerializationFeature.INDENT_OUTPUT);
 
         try {
             return mapper.writeValueAsString(agents);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
@@ -150,7 +150,6 @@ public class Package {
     @Override
     public String toString() {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.enable(SerializationFeature.INDENT_OUTPUT);
 
         try {
             return mapper.writeValueAsString(this);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/ReplicationResponse.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/ReplicationResponse.java
@@ -17,6 +17,7 @@
 package com.adobe.cq.cloud.testing.it.smoke.replication.data;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
 
@@ -82,7 +83,7 @@ public class ReplicationResponse {
 
     @Override 
     public String toString() {
-        return "ReplicationResponse{" + "code=" + code + ", message='" + message + '\'' + ", artifactId='" + artifactId
-            + '\'' + '}';
+        return "ReplicationResponse{code=" + code + ", message=\"" + StringUtils.normalizeSpace(message) + "\", artifactId=\"" + artifactId
+            + "\"}";
     }
 }


### PR DESCRIPTION
## Description

* Remove newlines from response messages received
* Add retry to Author/Publish ServiceAccessibleRule

## Related Issue

https://github.com/adobe/aem-test-samples/issues/32

## Motivation and Context

Logs uploaded to external service (e.g. splunk) may truncate on newlines. 
Add resilience to service up checks

## How Has This Been Tested?

Changes tested on a cloud environment

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
