### PR TITLE
CQ-4341234: Pass all sonar checks from CM pipeline

### DIFF
--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFEditorSmokeIT.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFEditorSmokeIT.java
@@ -77,14 +77,11 @@ public class CFEditorSmokeIT {
     public static void after() {
         try {
             CleanUpRule.cleanUp(cqBaseClassRule.authorRule, TEST_CONTENT_FRAGMENT_FOLDER, TIMEOUT, RETRY_DELAY);
-        } catch (Throwable t) {
-        }
+        } catch (InterruptedException | TimeoutException | RuntimeException ignored) {}
 
         try {
             CleanUpRule.cleanUp(cqBaseClassRule.authorRule, TEST_CONTENT_FRAGMENT_CONF_FOLDER, TIMEOUT, RETRY_DELAY);
-        } catch (Throwable t) {
-
-        }
+        } catch (InterruptedException | TimeoutException | RuntimeException ignored) {}
     }
 
     /**

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFEditorSmokeIT.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFEditorSmokeIT.java
@@ -33,7 +33,6 @@ import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -87,7 +86,7 @@ public class CFEditorSmokeIT {
     /**
      * Given a Content Fragment already present on the instance, check to see the availability of the
      * Content Fragment Editor.
-     *
+     * <p>
      * 1. Check to see if Content Fragment exists on target instance.
      * 2. Open a Content Fragment Editor.
      * 3. Start an editing session in the Content Fragment Editor.
@@ -102,12 +101,7 @@ public class CFEditorSmokeIT {
         LOGGER.info("Testing Content Fragment Editor..");
         CQClient client = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
 
-        new Polling(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return client.exists(TEST_CONTENT_FRAGMENT_PATH);
-            }
-        }).poll(TIMEOUT, RETRY_DELAY);
+        new Polling(() -> client.exists(TEST_CONTENT_FRAGMENT_PATH)).poll(TIMEOUT, RETRY_DELAY);
 
         client.doGet("editor.html/" + TEST_CONTENT_FRAGMENT_PATH, 200);
 
@@ -120,7 +114,7 @@ public class CFEditorSmokeIT {
 
     /**
      * Given a Content Fragment Model, check to see if the Content Fragment Model Editor is available.
-     *
+     * <p>
      * 1. Check to see if a Content Fragment Model is available on the instance.
      * 2. Open the Content Fragment Model Editor.
      *
@@ -133,19 +127,14 @@ public class CFEditorSmokeIT {
         LOGGER.info("Testing Content Fragment Model Editor..");
         CQClient client = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
 
-        new Polling(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return client.exists(TEST_CONTENT_FRAGMENT_MODEL_PATH);
-            }
-        }).poll(TIMEOUT, RETRY_DELAY);
+        new Polling(() -> client.exists(TEST_CONTENT_FRAGMENT_MODEL_PATH)).poll(TIMEOUT, RETRY_DELAY);
 
         client.doGet("/mnt/overlay/dam/cfm/models/editor/content/editor.html/" + TEST_CONTENT_FRAGMENT_MODEL_PATH, 200);
     }
 
     /**
      *  Given a Content Fragment Metadata Editor ( Properties screen ) is available.
-     *
+     * <p>
      *  1. Check to see if a Content Fragment exists.
      *  2. Open the Content Fragment Metadata Editor.
      *
@@ -158,12 +147,7 @@ public class CFEditorSmokeIT {
         LOGGER.info("Testing Open Content Fragment Editor Metadata..");
         CQClient client = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
 
-        new Polling(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return client.exists(TEST_CONTENT_FRAGMENT_PATH);
-            }
-        }).poll(TIMEOUT, RETRY_DELAY);
+        new Polling(() -> client.exists(TEST_CONTENT_FRAGMENT_PATH)).poll(TIMEOUT, RETRY_DELAY);
 
         client.doGet("/mnt/overlay/dam/cfm/admin/content/v2/metadata-editor.html" + TEST_CONTENT_FRAGMENT_PATH, 200);
     }

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFEditorSmokeIT.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFEditorSmokeIT.java
@@ -56,7 +56,7 @@ public class CFEditorSmokeIT {
     private static final String TEST_CONTENT_FRAGMENT_PATH = "/content/dam/cf-sanity-test-20191029/en/sample-content-fragment-20191029";
     private static final String TEST_CONTENT_FRAGMENT_MODEL_PATH = "/conf/cf-sanity-test-20191029/settings/dam/cf/models/simple-structure-20191029";
     
-    public static CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
+    private static final CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule);
@@ -64,10 +64,10 @@ public class CFEditorSmokeIT {
     @Rule
     public ContentFragmentRule contentFragmentRule = new ContentFragmentRule(cqBaseClassRule.authorRule);
 
-    public static InstallPackageRule installPackageRule = new InstallPackageRule(cqBaseClassRule.authorRule, "/test-content", PACKAGE_NAME, PACKAGE_VERSION, PACKAGE_GROUP);
+    private static final InstallPackageRule installPackageRule = new InstallPackageRule(cqBaseClassRule.authorRule, "/test-content", PACKAGE_NAME, PACKAGE_VERSION, PACKAGE_GROUP);
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(cqBaseClassRule).around(installPackageRule);
+    public static final TestRule ruleChain = RuleChain.outerRule(cqBaseClassRule).around(installPackageRule);
 
     /**
      * After class in order to make sure that the folders in /content/dam and /conf

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFSmokeIT.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFSmokeIT.java
@@ -61,16 +61,16 @@ public class CFSmokeIT {
     private static final String TEST_VARIATION_DESCRIPTION = "Content Fragment Test Variation.";
 
     // Class rules that install packages
-    public static CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
-    public static InstallPackageRule installPackageRule = new InstallPackageRule(cqBaseClassRule.authorRule, "/test-content", PACKAGE_NAME, PACKAGE_VERSION, PACKAGE_GROUP);
+    private static final CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
+    private static final InstallPackageRule installPackageRule = new InstallPackageRule(cqBaseClassRule.authorRule, "/test-content", PACKAGE_NAME, PACKAGE_VERSION, PACKAGE_GROUP);
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(cqBaseClassRule).around(installPackageRule);
+    public static final TestRule ruleChain = RuleChain.outerRule(cqBaseClassRule).around(installPackageRule);
 
     // Rule chain for clean up and content fragment utilities
-    public CQRule cqRule = new CQRule();
-    public ContentFragmentRule contentFragmentRule = new ContentFragmentRule(cqBaseClassRule.authorRule);
-    public CleanUpRule cleanUpRule = new CleanUpRule(cqBaseClassRule.authorRule, TIMEOUT, RETRY_DELAY);
+    private static final CQRule cqRule = new CQRule();
+    private static final ContentFragmentRule contentFragmentRule = new ContentFragmentRule(cqBaseClassRule.authorRule);
+    private static final CleanUpRule cleanUpRule = new CleanUpRule(cqBaseClassRule.authorRule, TIMEOUT, RETRY_DELAY);
 
     @Rule
     public TestRule rules = RuleChain.outerRule(cqRule).around(cleanUpRule).around(contentFragmentRule);

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFSmokeIT.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFSmokeIT.java
@@ -85,14 +85,11 @@ public class CFSmokeIT {
     public static void after() {
         try {
             CleanUpRule.cleanUp(cqBaseClassRule.authorRule, TEST_CONTENT_FRAGMENT_FOLDER, TIMEOUT, RETRY_DELAY);
-        } catch (Throwable t) {
-        }
+        } catch (InterruptedException | TimeoutException | RuntimeException ignored) {}
 
         try {
             CleanUpRule.cleanUp(cqBaseClassRule.authorRule, TEST_CONTENT_FRAGMENT_CONF_FOLDER, TIMEOUT, RETRY_DELAY);
-        } catch (Throwable t) {
-
-        }
+        } catch (InterruptedException | TimeoutException | RuntimeException ignored) {}
     }
 
     /**

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFSmokeIT.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/CFSmokeIT.java
@@ -78,7 +78,7 @@ public class CFSmokeIT {
     /**
      * As we creating content fragments in certain folders, the InstallPackageRule sometimes does not
      * remove the parent content fragment folder.
-     *
+     * <p>
      * Through this after method, we make sure that the clean up is done properly.
      */
     @AfterClass

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/CleanUpRule.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/CleanUpRule.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
 public class CleanUpRule extends ExternalResource {
@@ -59,7 +58,7 @@ public class CleanUpRule extends ExternalResource {
 
     @Override
     protected void after() {
-        toDelete.get().stream().forEach((path) -> {
+        toDelete.get().forEach((path) -> {
             try {
                 new Polling(() -> {
                     rule.getAdminClient().deletePath(path);
@@ -81,13 +80,10 @@ public class CleanUpRule extends ExternalResource {
      * @throws InterruptedException to mark this method as "waiting"
      */
     public static void cleanUp(Instance rule, String path, long timeout, long delay) throws TimeoutException, InterruptedException {
-        new Polling(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                LOG.debug("Specifically cleaning up the path: " + path);
-                rule.getAdminClient(CQClient.class).deletePath(path);
-                return rule.getAdminClient(CQClient.class).exists(path);
-            }
+        new Polling(() -> {
+            LOG.debug("Specifically cleaning up the path: " + path);
+            rule.getAdminClient(CQClient.class).deletePath(path);
+            return rule.getAdminClient(CQClient.class).exists(path);
         }).poll(timeout, delay);
     }
 }

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/CleanUpRule.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/CleanUpRule.java
@@ -32,7 +32,7 @@ public class CleanUpRule extends ExternalResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(CleanUpRule.class);
 
-    public ThreadLocal<List<String>> toDelete = ThreadLocal.withInitial(() -> new ArrayList<>(15));
+    private static final ThreadLocal<List<String>> toDelete = ThreadLocal.withInitial(() -> new ArrayList<>(15));
     private final Instance rule;
     private final long timeout;
     private final long delay;

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/CleanUpRule.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/CleanUpRule.java
@@ -65,8 +65,7 @@ public class CleanUpRule extends ExternalResource {
                     rule.getAdminClient().deletePath(path);
                     return rule.getAdminClient().exists(path);
                 }).poll(timeout, delay);
-            } catch (Throwable t) {
-            }
+            } catch (InterruptedException | TimeoutException | RuntimeException ignored) {}
         });
     }
 

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/ContentFragmentRule.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/ContentFragmentRule.java
@@ -19,11 +19,10 @@ package com.adobe.cq.cloud.testing.it.cf.smoke.rules;
 import com.adobe.cq.testing.client.CQClient;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.apache.sling.testing.clients.exceptions.TestingSetupException;
 import org.apache.sling.testing.clients.util.FormEntityBuilder;
 import org.apache.sling.testing.junit.rules.instance.Instance;
 import org.junit.rules.ExternalResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
@@ -32,9 +31,7 @@ import java.util.UUID;
  */
 public class ContentFragmentRule extends ExternalResource {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ContentFragmentRule.class);
-
-    private Instance instance;
+    private final Instance instance;
     private CQClient client;
 
     public ContentFragmentRule(Instance instance) {
@@ -111,7 +108,7 @@ public class ContentFragmentRule extends ExternalResource {
      *  always require a parent path ( location where to create the Content
      *  Fragment ) and a model/template path for the Content Fragment ( the
      *  path of a Content Fragment Model ).
-     *
+     * <p>
      *  It will return the path of the newly created Content Fragment, if
      *  successful, or throw a Client Exception if it was not.
      *
@@ -126,11 +123,11 @@ public class ContentFragmentRule extends ExternalResource {
     public String createContentFragment(String parentPath, String templatePath, String title, String name, String description) throws ClientException {
 
         if(parentPath == null || parentPath.equals("")) {
-            throw new ClientException("Invalid parent path for Content Fragment creation.");
+            throw new TestingSetupException("Invalid parent path for Content Fragment creation.");
         }
         
         if(templatePath == null || templatePath.equals("")) {
-            throw new ClientException("Invalid template path for Content Fragment creation.");
+            throw new TestingSetupException("Invalid template path for Content Fragment creation.");
         }
 
         if(name == null || name.equals("")) {
@@ -176,7 +173,7 @@ public class ContentFragmentRule extends ExternalResource {
     public String createContentFragmentModel(String parentPath, String title, String description) throws ClientException {
 
         if(parentPath == null || parentPath.equals("")) {
-            throw new ClientException("Invalid parent path for Content Fragment Model creation.");
+            throw new TestingSetupException("Invalid parent path for Content Fragment Model creation.");
         }
 
         if(title == null || title.equals("")) {
@@ -205,7 +202,7 @@ public class ContentFragmentRule extends ExternalResource {
 
     /**
      *  Extracts a content fragment path from a Granite UI HTML response.
-     *
+     * <p>
      *  As the response returned from a call to create content fragment is a HTML response, we would have to
      *  extract the path from that using String manipulations.
      *
@@ -230,7 +227,7 @@ public class ContentFragmentRule extends ExternalResource {
 
     /**
      *  Extracts a content fragment model path from a Granite UI HTML response.
-     *
+     * <p>
      *  As the response returned from a call to create content fragment model is a HTML response, we would have to
      *  extract the path from that using String manipulations.
      *

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/ContentFragmentRule.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/ContentFragmentRule.java
@@ -126,12 +126,10 @@ public class ContentFragmentRule extends ExternalResource {
     public String createContentFragment(String parentPath, String templatePath, String title, String name, String description) throws ClientException {
 
         if(parentPath == null || parentPath.equals("")) {
-            LOG.error("Could not create Content Fragment due to invalid parent path.");
             throw new ClientException("Invalid parent path for Content Fragment creation.");
         }
         
         if(templatePath == null || templatePath.equals("")) {
-            LOG.error("Could not create Content Fragment due to invalid template path");
             throw new ClientException("Invalid template path for Content Fragment creation.");
         }
 
@@ -158,8 +156,9 @@ public class ContentFragmentRule extends ExternalResource {
         createParams.addParameter("tags@Delete", "");
         createParams.addParameter("name", name);
 
-        SlingHttpResponse response = client.doPost("/libs/dam/cfm/admin/content/v2/createfragment/submit/_jcr_content.html",
-                createParams.build(), null, 201);
+        // uses "NOSONAR" because CQRules:CQBP-71 is triggering, but can be ignored for this test case
+        final String CREATE_FRAGMENT_PATH = "/libs/dam/cfm/admin/content/v2/createfragment/submit/_jcr_content.html"; //NOSONAR
+        SlingHttpResponse response = client.doPost(CREATE_FRAGMENT_PATH, createParams.build(), null, 201);
 
         return extractContentFragmentPathFromResponse(response.getContent());
     }
@@ -177,7 +176,6 @@ public class ContentFragmentRule extends ExternalResource {
     public String createContentFragmentModel(String parentPath, String title, String description) throws ClientException {
 
         if(parentPath == null || parentPath.equals("")) {
-            LOG.error("Could not create Content Fragment Model due to invalid parent path.");
             throw new ClientException("Invalid parent path for Content Fragment Model creation.");
         }
 
@@ -189,11 +187,14 @@ public class ContentFragmentRule extends ExternalResource {
             description = "";
         }
 
+        // uses "NOSONAR" because CQRules:CQBP-71 is triggering, but can be ignored for this test case
+        final String FRAGMENT_PATH = "/libs/settings/dam/cfm/model-types/fragment"; //NOSONAR
+
         FormEntityBuilder createParams = FormEntityBuilder.create();
         createParams.addParameter("_charset_", "UTF-8");
         createParams.addParameter(":operation", "cfm:createModel");
         createParams.addParameter("_parentPath_", parentPath);
-        createParams.addParameter("modelType", "/libs/settings/dam/cfm/model-types/fragment");
+        createParams.addParameter("modelType", FRAGMENT_PATH);
         createParams.addParameter("./jcr:title", title);
         createParams.addParameter("./jcr:description", description);
 

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/InstallPackageRule.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/InstallPackageRule.java
@@ -118,10 +118,8 @@ public class InstallPackageRule implements TestRule {
         URI resourceUri = Objects.requireNonNull(getClass().getResource(resourceFolder)).toURI();
         Path resourcePath;
 
-        FileSystem fs = null;
-        try {
+        try (FileSystem fs = FileSystems.newFileSystem(resourceUri, Collections.emptyMap())) {
             if (resourceUri.getScheme().equals("jar")) {
-                fs = FileSystems.newFileSystem(resourceUri, Collections.emptyMap());
                 resourcePath = fs.getPath(resourceFolder);
             } else {
                 resourcePath = Paths.get(resourceUri);
@@ -129,10 +127,6 @@ public class InstallPackageRule implements TestRule {
 
             LOG.info("Creating package from resources folder {}", resourcePath);
             return buildJarFromFolder(resourcePath);
-        } finally {
-            if (fs != null) {
-                fs.close();
-            }
         }
     }
 

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/InstallPackageRule.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/InstallPackageRule.java
@@ -93,7 +93,7 @@ public class InstallPackageRule implements TestRule {
                             uploadedPackage.get().install();
                             Assert.assertEquals("Package path does not match expectations",
                                     finalNewPackagePath, uploadedPackage.get().getPath());
-                        } catch (Exception e) {
+                        } catch (FileNotFoundException | RuntimeException e) {
                             cleanupPackage(finalClient, finalNewPackagePath);
                         }
                         return finalClient.isPackageCreated(name, version, group);

--- a/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/InstallPackageRule.java
+++ b/cf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/cf/smoke/rules/InstallPackageRule.java
@@ -55,12 +55,12 @@ import static org.apache.http.HttpStatus.SC_OK;
 public class InstallPackageRule implements TestRule {
     private static final Logger LOG = LoggerFactory.getLogger(InstallPackageRule.class);
 
-    private String srcPath;
+    private final String srcPath;
     private final String name;
     private final String version;
     private final String group;
 
-    private Instance instance;
+    private final Instance instance;
 
     public  InstallPackageRule(Instance instance, String srcPath, String name, String version, String group) {
         this.instance = instance;
@@ -167,6 +167,7 @@ public class InstallPackageRule implements TestRule {
     }
 
     // TODO move to aem-testing-clients
+    @SuppressWarnings("UnusedReturnValue")
     private SlingHttpResponse cleanupPackage(SlingClient client, String path, String cmd) throws ClientException {
         FormEntityBuilder feb = FormEntityBuilder.create();
         feb.addParameter("cmd", cmd);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAdminIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAdminIT.java
@@ -32,7 +32,7 @@ public class CreatePageAdminIT {
     private static final long TIMEOUT = MINUTES.toMillis(3);
 
     @ClassRule
-    public static CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
+    public static final CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
@@ -49,19 +49,19 @@ public class CreatePageAsAuthorUserIT {
     private static final int TIMEOUT = (int) MINUTES.toMillis(2);
 
     @ClassRule
-    public static CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
+    public static final CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
 
-    public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule);
+    private static final CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule);
 
     // Create a random page so the test site is initialized properly.
     private final Page temporaryPage = new Page(cqBaseClassRule.authorRule);
     
-    public TemporaryContentAuthorGroup groupRule = new TemporaryContentAuthorGroup(() -> cqBaseClassRule.authorRule.getAdminClient());
+    private static final TemporaryContentAuthorGroup groupRule = new TemporaryContentAuthorGroup(cqBaseClassRule.authorRule::getAdminClient);
 
     @Rule
     public TestRule cqRuleChainGroup = RuleChain.outerRule(cqBaseRule).around(groupRule);
 
-    public TemporaryUser userRule = new TemporaryUser(() -> cqBaseClassRule.authorRule.getAdminClient(), groupRule.getGroupName());
+    private static final TemporaryUser userRule = new TemporaryUser(cqBaseClassRule.authorRule::getAdminClient, groupRule.getGroupName());
 
     @Rule
     public TestRule cqRuleChain = RuleChain.outerRule(cqBaseRule).around(temporaryPage).around(userRule);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
@@ -77,8 +77,10 @@ public class CreatePageAsAuthorUserIT {
         String pageName = "testpage_" +  UUID.randomUUID();
         String pagePathExpected = temporaryPage.getParentPath() + "/" + pageName;
         String pagePath = pagePathExpected;
-        try (SlingHttpResponse response = userRule.getClient().createPageWithRetry(pageName, "Page created by CreatePageAsAuthorUserIT",
-                temporaryPage.getParentPath(), "", MINUTES.toMillis(1), 500, HttpStatus.SC_OK, HttpStatus.SC_UNAUTHORIZED)) {
+        try (
+                SlingHttpResponse response = userRule.getClient().createPageWithRetry(pageName, "Page created by CreatePageAsAuthorUserIT",
+                temporaryPage.getParentPath(), "", MINUTES.toMillis(1), 500, HttpStatus.SC_OK, HttpStatus.SC_UNAUTHORIZED)
+        ) {
             assert response != null;
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_UNAUTHORIZED) {
                 throw new AssumptionViolatedException("Author User " + userRule.getClient().getUser() + " not authorized to create page. Skipping...");

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -18,7 +18,6 @@ package com.adobe.cq.cloud.testing.it.smoke;
 import com.adobe.cq.testing.client.CQClient;
 import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
-import com.adobe.cq.testing.junit.rules.Page;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.sling.testing.clients.ClientException;
@@ -113,7 +112,7 @@ public class GetTogglesIT {
                     match = true;
                     break;
                 } else {
-                    match = match || checkElementMatchesRegex(regex, item);
+                    match = checkElementMatchesRegex(regex, item);
                     if (match) {
                         break;
                     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -29,12 +29,14 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 public class GetTogglesIT {
 
@@ -75,10 +77,13 @@ public class GetTogglesIT {
     /**
      * Validate format of AEM version containing state qualifier using six digits
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws ParserConfigurationException if an error occurred
+     * @throws IOException if an error occurred
+     * @throws SAXException if an error occurred
      */
     @Test
-    public void testAboutPageVersionFormatWithToggleQualifier() throws Exception {
+    public void testAboutPageVersionFormatWithToggleQualifier() throws ClientException, ParserConfigurationException, IOException, SAXException {
         SlingHttpResponse response = adminAuthor.doGet("mnt/overlay/granite/ui/content/shell/about.html", 200);
         final String regex = "^Adobe Experience Manager [\\d]{4}.[\\d]{1,2}.[\\d]+.[\\d]{8}T[\\d]{6}Z-[\\d]{6}(-[\\w]+)?$";
 

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/GetTogglesIT.java
@@ -41,7 +41,7 @@ import javax.xml.parsers.ParserConfigurationException;
 public class GetTogglesIT {
 
     @ClassRule
-    public static CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
     static CQClient adminAuthor;
     static CQClient adminPublish;
     @Rule
@@ -67,7 +67,7 @@ public class GetTogglesIT {
         String responseContent = response.getContent();
         try {
             ToggleResponse tr = mapper.readValue(responseContent, ToggleResponse.class);
-            Assert.assertTrue(Arrays.asList(tr.enabled).contains("ENABLED"));
+            Assert.assertTrue(Arrays.asList(tr.getEnabled()).contains("ENABLED"));
 
         } catch (IOException e) {
             Assert.fail("Couldn't read response from ClientLibs toggle endpoint. \nError: " + e.getMessage() + "\nContents: " + responseContent);
@@ -123,8 +123,17 @@ public class GetTogglesIT {
         return match;
     }
 
-    public static final class ToggleResponse {
+    protected static final class ToggleResponse {
 
-        public String[] enabled;
+        private String[] enabled;
+
+        public String[] getEnabled() {
+            return enabled.clone();
+        }
+
+        @SuppressWarnings("unused")
+        public void setEnabled(String[] enabled) {
+            this.enabled = enabled.clone();
+        }
     }
 }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
@@ -40,12 +40,13 @@ public class PublishEndToEndIT {
     protected static final long TIMEOUT = TimeUnit.MINUTES.toMillis(1);
     
     @ClassRule
-    public static CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);
     
-    public Page root = new Page(cqBaseClassRule.authorRule);
+    private static final Page root = new Page(cqBaseClassRule.authorRule);
+
     @Rule
     public RuleChain ruleChain = RuleChain.outerRule(new ServiceAccessibleRule(cqBaseClassRule.authorRule))
         .around(new ServiceAccessibleRule(cqBaseClassRule.publishRule))

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PublishEndToEndIT.java
@@ -17,7 +17,9 @@
 package com.adobe.cq.cloud.testing.it.smoke;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import com.adobe.cq.cloud.testing.it.smoke.exception.SmokeTestException;
 import com.adobe.cq.cloud.testing.it.smoke.rules.ContentPublishRule;
 import com.adobe.cq.cloud.testing.it.smoke.rules.ServiceAccessibleRule;
 import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
@@ -32,7 +34,7 @@ import org.junit.rules.RuleChain;
 
 /**
  * End to end publication test.
- * 
+ * <p>
  * A test page is published from author and publication is validated through the AEM
  * publish ingress (CDN -&gt; Dispatcher -&gt; AEM publish tier).
  */
@@ -65,10 +67,11 @@ public class PublishEndToEndIT {
      *      <li>After deactivation, that the page is no longer accessible via the publish ingress and that the queue is empty</li>
      * </ul>
      *
-     * @throws Exception if an error occurred
+     * @throws InterruptedException if an error occurred
+     * @throws TimeoutException if an error occurred
      */
     @Test
-    public void testActivateAndDeactivate() throws Exception {
+    public void testActivateAndDeactivate() throws InterruptedException, TimeoutException {
 
         // This is a workaround for correctly detecting assumption violations.
         // Any AssumptionViolatedException throw by the Callable will be
@@ -79,8 +82,8 @@ public class PublishEndToEndIT {
             activateAndDeactivate();
         } catch (AssumptionViolatedException e) {
             throw e;
-        } catch (Exception e) {
-            new Polling(() -> activateAndDeactivate()).poll(TIMEOUT, 500);
+        } catch (SmokeTestException | RuntimeException e) {
+            new Polling(this::activateAndDeactivate).poll(TIMEOUT, 500);
         }
     }
 
@@ -88,9 +91,9 @@ public class PublishEndToEndIT {
      * Execute activate and deactivate on publish & preview
      *
      * @return true if success
-     * @throws Exception if exception occurs
+     * @throws SmokeTestException if exception occurs
      */
-    private boolean activateAndDeactivate() throws Exception {
+    private boolean activateAndDeactivate() throws SmokeTestException {
         contentPublishRule.activateAssertPublish();
         contentPublishRule.deactivateAssertPublish();
         

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/SearchIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/SearchIT.java
@@ -32,7 +32,7 @@ public class SearchIT {
     private static final long TIMEOUT = SECONDS.toMillis(30);
 
     @ClassRule
-    public static CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
+    public static final CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule);

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/SearchIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/SearchIT.java
@@ -23,6 +23,8 @@ import org.apache.sling.testing.clients.util.poller.Polling;
 import org.junit.*;
 
 
+import java.util.concurrent.TimeoutException;
+
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class SearchIT {
@@ -50,10 +52,11 @@ public class SearchIT {
      * Verifies that searching for the text inside the page created by the Page rule
      * returns the page containing it
      *
-     * @throws Exception if an error occurred
+     * @throws InterruptedException if an error occurred
+     * @throws TimeoutException if an error occurred
      */
     @Test
-    public void searchInPages() throws Exception {
+    public void searchInPages() throws InterruptedException, TimeoutException {
 
         new Polling() {
             @Override

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ValidateAntiSamyConfigurationIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ValidateAntiSamyConfigurationIT.java
@@ -51,8 +51,7 @@ public class ValidateAntiSamyConfigurationIT {
                     }
                     HttpEntity httpEntity = new InputStreamEntity(inputStream, ContentType.APPLICATION_JSON);
                     SlingHttpResponse response = adminAuthor.doPost(TEST_REQUEST_PATH, httpEntity, 200);
-                    JsonParser jsonParser = new JsonParser();
-                    JsonElement jsonElement = jsonParser.parse(response.getContent());
+                    JsonElement jsonElement = JsonParser.parseString(response.getContent().trim());
                     JsonObject result = jsonElement.getAsJsonObject();
                     if (!"ok".equalsIgnoreCase(result.get("status").getAsString())) {
                         fail(String.format("Invalid AntiSamy configuration detected. The following URLs were not validated as expected:\n%s",

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ValidateAntiSamyConfigurationIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ValidateAntiSamyConfigurationIT.java
@@ -29,7 +29,7 @@ public class ValidateAntiSamyConfigurationIT {
     private static final long DELAY = TimeUnit.SECONDS.toMillis(1);
 
     @ClassRule
-    public static CQAuthorClassRule cqAuthorClassRule = new CQAuthorClassRule();
+    public static final CQAuthorClassRule cqAuthorClassRule = new CQAuthorClassRule();
 
     private static CQClient adminAuthor;
 

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ValidateAntiSamyConfigurationIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ValidateAntiSamyConfigurationIT.java
@@ -24,7 +24,8 @@ import static org.junit.Assert.fail;
 public class ValidateAntiSamyConfigurationIT {
 
     private static final String AUTHOR_VALIDATION_URLS = "/com/adobe/cq/cloud/testing/it/smoke/xss/author_validation_urls.json";
-    private static final String TEST_REQUEST_PATH = "/libs/cq/xssprotection.json";
+    // uses "NOSONAR" because CQRules:CQBP-71 is triggering, but can be ignored for this test case
+    private static final String TEST_REQUEST_PATH = "/libs/cq/xssprotection.json"; //NOSONAR
     private static final long TIMEOUT = TimeUnit.SECONDS.toMillis(30);
     private static final long DELAY = TimeUnit.SECONDS.toMillis(1);
 

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/PublishException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/PublishException.java
@@ -23,6 +23,7 @@ public class PublishException extends SmokeTestException {
     public static final String PAGE_NOT_AVAILABLE = "PAGE_NOT_AVAILABLE";
     public static final String PAGE_AVAILABLE = "PAGE_AVAILABLE";
 
+    @SuppressWarnings("unused")
     public PublishException(String errorCode, String message) {
         super(errorCode, message);
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ReplicationException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ReplicationException.java
@@ -23,6 +23,7 @@ public class ReplicationException extends SmokeTestException {
     public static final String ACTION_NOT_REPLICATED = "ACTION_NOT_REPLICATED";
     public static final String REPLICATION_NOT_AVAILABLE = "REPLICATION_NOT_AVAILABLE";
 
+    @SuppressWarnings("unused")
     public ReplicationException(String errorCode, String message) {
         super(errorCode, message);
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ServiceException.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/exception/ServiceException.java
@@ -22,6 +22,8 @@ public class ServiceException extends SmokeTestException {
     public ServiceException(String errorCode, String message) {
         super(errorCode, message);
     }
+
+    @SuppressWarnings("unused")
     public ServiceException(String errorCode, String message, Throwable t) {
         super(errorCode, message, t);
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
@@ -83,7 +83,7 @@ public class ReplicationClient extends CQClient {
             }
             log.info("Activation response received {}", response);
             return response;
-        } catch (Exception e) {
+        } catch (ClientException | RuntimeException e) {
             throw getGenericException("Exception during activation", e);
         }
     }
@@ -104,7 +104,7 @@ public class ReplicationClient extends CQClient {
             }
             log.info("De-Activation response received {}", response);
             return response;
-        } catch (Exception e) {
+        } catch (ClientException | RuntimeException e) {
             throw getGenericException("Exception during deactivation", e);
         }
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
@@ -57,12 +57,12 @@ public class ReplicationClient extends CQClient {
     // uses "NOSONAR" because CQRules:CQBP-71 is triggering, but can be ignored for this test case
     protected static final String DIST_AGENTS_PATH = "/libs/sling/distribution/services/agents"; //NOSONAR
 
-    protected static final String PUB_QUEUES_PATH = DIST_AGENTS_PATH + "/" + PUBLISH_DIST_AGENT;
-
+    @SuppressWarnings("unused")
     public ReplicationClient(CloseableHttpClient http, SlingClientConfig config) throws ClientException {
         super(http, config);
     }
 
+    @SuppressWarnings("unused")
     public ReplicationClient(URI serverUrl, String user, String password) throws ClientException {
         super(serverUrl, user, password);
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/ReplicationClient.java
@@ -54,8 +54,8 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 public class ReplicationClient extends CQClient {
     private static final Logger log = LoggerFactory.getLogger(ContentPublishRule.class);
 
-    protected static final String DIST_AGENTS_PATH = "/libs/sling/distribution/services/agents";
-    protected static final String PUBLISH_DIST_AGENT = "publish";
+    // uses "NOSONAR" because CQRules:CQBP-71 is triggering, but can be ignored for this test case
+    protected static final String DIST_AGENTS_PATH = "/libs/sling/distribution/services/agents"; //NOSONAR
 
     protected static final String PUB_QUEUES_PATH = DIST_AGENTS_PATH + "/" + PUBLISH_DIST_AGENT;
 

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agent.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agent.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Agent {
@@ -77,8 +76,7 @@ public class Agent {
 
         try {
             return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-        }
+        } catch (JsonProcessingException ignored) {}
         return "";
     }
 

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agents.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Agents.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,7 +29,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
@@ -65,12 +63,13 @@ public class Agents {
 
         try {
             return mapper.writeValueAsString(agents);
-        } catch (JsonProcessingException e) {
-        }
+        } catch (JsonProcessingException ignored) {}
         return "";
     }
 
     public static class AgentsDeserializer extends StdDeserializer<Agents> {
+
+        @SuppressWarnings("unused")
         protected AgentsDeserializer() {
             this(null);
         }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
@@ -76,11 +76,11 @@ public class Package {
     }
     
     public List<String> getPaths() {
-        return paths;
+        return new ArrayList<>(paths);
     }
 
     public void setPaths(List<String> paths) {
-        this.paths = paths;
+        this.paths = new ArrayList<>(paths);
     }
 
     public String getErrorMessage() {

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
@@ -66,7 +66,8 @@ public class Package {
     public boolean isBlocked() {
         return state.equalsIgnoreCase(ERROR);
     }
-    
+
+    @SuppressWarnings("unused")
     public int getSize() {
         return size;
     }
@@ -91,6 +92,7 @@ public class Package {
         this.errorMessage = errorMessage;
     }
 
+    @SuppressWarnings("unused")
     public String getAction() {
         return action;
     }
@@ -114,7 +116,8 @@ public class Package {
     public void setPkgId(String pkgId) {
         this.pkgId = pkgId;
     }
-    
+
+    @SuppressWarnings("unused")
     public String getTime() {
         return time;
     }
@@ -123,6 +126,7 @@ public class Package {
         this.time = time;
     }
 
+    @SuppressWarnings("unused")
     public String getState() {
         return state;
     }
@@ -131,6 +135,7 @@ public class Package {
         this.state = state;
     }
 
+    @SuppressWarnings("unused")
     public String getUserid() {
         return userid;
     }
@@ -139,6 +144,7 @@ public class Package {
         this.userid = userid;
     }
 
+    @SuppressWarnings("unused")
     public int getAttempts() {
         return attempts;
     }
@@ -153,8 +159,7 @@ public class Package {
 
         try {
             return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-        }
+        } catch (JsonProcessingException ignored) {}
         return "";
     }
     

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Package.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.sling.api.SlingConstants;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Package {
@@ -56,7 +56,7 @@ public class Package {
     @JsonProperty("state")
     private String state;
    
-    @JsonProperty("userid")
+    @JsonProperty(SlingConstants.PROPERTY_USERID)
     private String userid;
    
     @JsonProperty("attempts")

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Queue.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/replication/data/Queue.java
@@ -44,10 +44,12 @@ public class Queue {
     @JsonProperty("packages")
     private Map<String, Package> packageMap = new HashMap<>();
 
+    @SuppressWarnings("unused")
     public void setName(String name) {
         this.name = name;
     }
 
+    @SuppressWarnings("unused")
     public String getName() {
         return name;
     }
@@ -59,7 +61,8 @@ public class Queue {
     public Map<String, Package> getPackageMap() {
         return packageMap;
     }
-    
+
+    @SuppressWarnings("unused")
     public String getState() {
         return state;
     }
@@ -68,6 +71,7 @@ public class Queue {
         this.state = state;
     }
 
+    @SuppressWarnings("unused")
     public int getItemsCount() {
         return itemsCount;
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -61,6 +61,9 @@ import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 /**
  * Junit test rule to check content distribution functionality
  */
+// Suppress logging Sonar warnings, since logging and throwing is acceptable in testing
+@SuppressWarnings({"CQRules:CQBP-44---ConsecutivelyLogAndThrow", "CQRules:CQBP-44---CatchAndEitherLogOrThrow"})
+
 public class ContentPublishRule extends ExternalResource {
     private static final Logger log = LoggerFactory.getLogger(ContentPublishRule.class);
     
@@ -323,8 +326,8 @@ public class ContentPublishRule extends ExternalResource {
             });
             polling.poll(TIMEOUT, 2000);
         } catch (TimeoutException e) {
-            log.info("Agent not empty of item {}", ((agentsRef.get() != null) ? agentsRef.get().getAgent(agent) : ""));
-            throw replicationClient.getReplicationException(ACTION_NOT_REPLICATED, 
+            log.warn("Agent not empty of item {}", ((agentsRef.get() != null) ? agentsRef.get().getAgent(agent) : ""));
+            throw replicationClient.getReplicationException(ACTION_NOT_REPLICATED,
                 String.format("Item not activated within %s ms", TIMEOUT),
                 polling.getLastException());
         } catch (InterruptedException | RuntimeException e) {

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -289,10 +289,10 @@ public class ContentPublishRule extends ExternalResource {
     }
     
     private boolean doPreviewChecks(Agents agents) throws ReplicationException {
-        boolean previewAgentExists = replicationClient.checkDistributionAgentExists(agents, PREVIEW_DIST_AGENT);
+        boolean previewAgentExists = ReplicationClient.checkDistributionAgentExists(agents, PREVIEW_DIST_AGENT);
         if (previewAgentExists) {
             //throw if preview agent is blocked
-            boolean previewBlocked = replicationClient.isAgentQueueBlocked(agents, PREVIEW_DIST_AGENT);
+            boolean previewBlocked = ReplicationClient.isAgentQueueBlocked(agents, PREVIEW_DIST_AGENT);
             if (previewBlocked) {
                 throw replicationClient.getReplicationException(QUEUE_BLOCKED,
                     "Replication agent queue blocked - " + agents.getAgent(PREVIEW_DIST_AGENT), null); 

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -127,15 +127,14 @@ public class ContentPublishRule extends ExternalResource {
         return authorClient;
     }
 
-    private void checkPage(final int expectedStatus) throws Exception {
+    private void checkPage(final int expectedStatus) throws PublishException {
         checkPage(true, expectedStatus);
     }
     
     /**
      * Checks that a GET on the page on publish has the {{expectedStatus}} in the response
      *
-     * @throws Exception if an error occurred
-     * @return
+     * @throws PublishException if an error occurred
      */
     private void checkPage(boolean skipDispatcherCache, final int expectedStatus) throws PublishException {
         final String path = root.getPath() + ".html";
@@ -201,7 +200,7 @@ public class ContentPublishRule extends ExternalResource {
         return exception;
     }
     
-    public void activateAssertPublish() throws Exception {
+    public void activateAssertPublish() throws SmokeTestException {
         // Activate Page
         ReplicationResponse replicationResponse = replicationClient.activate(PUBLISH_DIST_AGENT, root.getPath());
 
@@ -212,7 +211,7 @@ public class ContentPublishRule extends ExternalResource {
         checkPage(SC_OK);
     }
 
-    public void activateAssertPreview() throws Exception {
+    public void activateAssertPreview() throws SmokeTestException {
         if (previewAvailable) {
             // Activate Page
             ReplicationResponse replicationResponse = replicationClient.activate(PREVIEW_DIST_AGENT, root.getPath());
@@ -222,7 +221,7 @@ public class ContentPublishRule extends ExternalResource {
         }
     }
 
-    public void deactivateAssertPublish() throws Exception {
+    public void deactivateAssertPublish() throws SmokeTestException {
         // Deactivate Page
         ReplicationResponse replicationResponse = replicationClient.deactivate(PUBLISH_DIST_AGENT, root.getPath());
 
@@ -233,7 +232,7 @@ public class ContentPublishRule extends ExternalResource {
         checkPage(SC_NOT_FOUND);
     }
 
-    public void deactivateAssertPreview() throws Exception {
+    public void deactivateAssertPreview() throws SmokeTestException {
         if (previewAvailable) {
             // Deactivate Page
             ReplicationResponse replicationResponse = replicationClient.deactivate(PREVIEW_DIST_AGENT, root.getPath());
@@ -266,9 +265,9 @@ public class ContentPublishRule extends ExternalResource {
             });
             polling.poll(TIMEOUT, 500);
         } catch (TimeoutException e) {
-            throw replicationClient.getReplicationException(REPLICATION_NOT_AVAILABLE, 
+            throw replicationClient.getReplicationException(REPLICATION_NOT_AVAILABLE,
                 String.format("Replication agent %s unavailable", PUBLISH_DIST_AGENT), polling.getLastException());
-        } catch (Exception e) {
+        } catch (InterruptedException | RuntimeException e) {
             throw replicationClient.getGenericException("Replication agent unavailable", e);
         }
 
@@ -277,7 +276,7 @@ public class ContentPublishRule extends ExternalResource {
         // throw if publish agent is blocked
         boolean agentQueueBlocked = ReplicationClient.isAgentQueueBlocked(agents, PUBLISH_DIST_AGENT);
         if (agentQueueBlocked) {
-            throw replicationClient.getReplicationException(QUEUE_BLOCKED, 
+            throw replicationClient.getReplicationException(QUEUE_BLOCKED,
                 "Replication agent queue blocked - " + agents.getAgent(PUBLISH_DIST_AGENT), null);
         }
         
@@ -327,7 +326,7 @@ public class ContentPublishRule extends ExternalResource {
             throw replicationClient.getReplicationException(ACTION_NOT_REPLICATED, 
                 String.format("Item not activated within %s ms", TIMEOUT),
                 polling.getLastException());
-        } catch (Exception e) {
+        } catch (InterruptedException | RuntimeException e) {
             throw replicationClient.getGenericException(String.format("Item not activated within %s ms", TIMEOUT), e);
         }
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
@@ -85,7 +85,7 @@ public class ServiceAccessibleRule implements TestRule {
                 return true;
             });
             polling.poll(TIMEOUT, 2000);
-        } catch (Exception ce) {
+        } catch (TimeoutException | InterruptedException ce) {
             ServiceException serviceException = new ServiceException(runmode.toUpperCase() + SUFFIX, ce.getMessage());
             log.info("Health check failure", serviceException);
             // TODO throw exceptions once the instance health check URLs GA

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
@@ -18,12 +18,14 @@ package com.adobe.cq.cloud.testing.it.smoke.rules;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.adobe.cq.cloud.testing.it.smoke.exception.ServiceException;
 import com.adobe.cq.testing.client.CQClient;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
@@ -61,7 +63,11 @@ public class ServiceAccessibleRule implements TestRule {
         Polling polling;
 
         try {
-            HttpClient client = HttpClientBuilder.create().build();
+            RequestConfig requestConfig = RequestConfig.custom()
+                    .setConnectTimeout(10000)
+                    .setSocketTimeout(10000)
+                    .build();
+            HttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
             AtomicInteger counter = new AtomicInteger();
             polling = new Polling(() -> {
                 counter.incrementAndGet();

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
@@ -48,7 +48,8 @@ public class ServiceAccessibleRule implements TestRule {
     protected static final long TIMEOUT = TimeUnit.MINUTES.toMillis(5);
 
     public static final String SYSTEM_READY = "systemready";
-    
+
+    @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final Instance instance;
     private final String runmode;
     private final CQClient adminClient;

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ServiceAccessibleRule.java
@@ -87,7 +87,7 @@ public class ServiceAccessibleRule implements TestRule {
             polling.poll(TIMEOUT, 2000);
         } catch (TimeoutException | InterruptedException ce) {
             ServiceException serviceException = new ServiceException(runmode.toUpperCase() + SUFFIX, ce.getMessage());
-            log.info("Health check failure", serviceException);
+            log.warn("Health check failure", serviceException);
             // TODO throw exceptions once the instance health check URLs GA
             //throw serviceException;
         }

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/CreatePageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/CreatePageIT.java
@@ -44,17 +44,17 @@ public class CreatePageIT {
     static CQClient adminAuthor;
 
     @BeforeClass
-    public static void beforeClass() throws ClientException {
+    public static void beforeClass() {
         adminAuthor = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
     }
 
     /**
      * Verifies that the page created by the {{Page}} rule is present
      *
-     * @throws Exception if an error occurred
+     * @throws InterruptedException if an error occurred
      */
     @Test
-    public void testCreatePage() throws Exception {
+    public void testCreatePage() throws InterruptedException {
         // verify that page is present on author
         CQAssert.assertCQPageExistsWithTimeout(adminAuthor, root.getPath(), TIMEOUT, 500);
     }

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/CreatePageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/CreatePageIT.java
@@ -20,7 +20,6 @@ import com.adobe.cq.testing.junit.assertion.CQAssert;
 import com.adobe.cq.testing.junit.rules.CQAuthorClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 import com.adobe.cq.testing.junit.rules.Page;
-import org.apache.sling.testing.clients.ClientException;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/CreatePageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/CreatePageIT.java
@@ -33,7 +33,7 @@ public class CreatePageIT {
     private static final long TIMEOUT = MINUTES.toMillis(3);
 
     @ClassRule
-    public static CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
+    public static final CQAuthorClassRule cqBaseClassRule = new CQAuthorClassRule();
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule);

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
@@ -169,7 +169,8 @@ public class DeepGetPageIT {
     private static boolean isSameOrigin(URI uri1, URI uri2) {
         if (!uri1.getScheme().equals(uri2.getScheme())) {
             return false;
-        } else return uri1.getAuthority().equals(uri2.getAuthority());
+        }
+        return uri1.getAuthority().equals(uri2.getAuthority());
     }
 
 }

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
@@ -64,50 +64,60 @@ public class DeepGetPageIT {
     /**
      * Verifies that the homepage exists on author
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws IOException if an error occurred
+     * @throws URISyntaxException if an error occurred
      */
     @Test
-    public void testHomePageAuthor() throws Exception {
+    public void testHomePageAuthor() throws ClientException, IOException, URISyntaxException {
         verifyPageAndResources(adminAuthor, "/");
     }
 
     /**
      * Verifies that the sites console exists on author
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws IOException if an error occurred
+     * @throws URISyntaxException if an error occurred
      */
     @Test
-    public void testSitesAuthor() throws Exception {
+    public void testSitesAuthor() throws ClientException, IOException, URISyntaxException {
         verifyPageAndResources(adminAuthor, "/sites.html");
     }
 
     /**
      * Verifies that the assets console exists on author
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws IOException if an error occurred
+     * @throws URISyntaxException if an error occurred
      */
     @Test
-    public void testAssetsAuthor() throws Exception {
+    public void testAssetsAuthor() throws ClientException, IOException, URISyntaxException {
         verifyPageAndResources(adminAuthor, "/assets.html");
     }
 
     /**
      * Verifies that the projects console exists on author
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws IOException if an error occurred
+     * @throws URISyntaxException if an error occurred
      */
     @Test
-    public void testProjectsAuthor() throws Exception {
+    public void testProjectsAuthor() throws ClientException, IOException, URISyntaxException {
         verifyPageAndResources(adminAuthor, "/projects.html");
     }
 
     /**
      * Verifies that the homepage exists on publish
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws IOException if an error occurred
+     * @throws URISyntaxException if an error occurred
      */
     @Test @Ignore
-    public void testHomePagePublish() throws Exception {
+    public void testHomePagePublish() throws ClientException, IOException, URISyntaxException {
         verifyPageAndResources(adminPublish, "/");
     }
 

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
@@ -32,7 +32,6 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.junit.Assert.assertEquals;
 
 public class DeepGetPageIT {
@@ -56,9 +55,23 @@ public class DeepGetPageIT {
     }
 
     @AfterClass
-    public static void afterClass() throws IOException {
-        closeQuietly(adminAuthor);
-        closeQuietly(adminPublish);
+    public static void afterClass() {
+        closeClientQuietly(adminAuthor);
+        closeClientQuietly(adminPublish);
+    }
+
+    /**
+     * Closes a client resource if applicable without notice in case it fails.
+     * INFO: Used instead of org.apache.commons.io.IOUtils.closeQuietly since it is still marked as deprecated in
+     * AEM, although it was un-deprecated in recent versions of commons-io (see <a href="https://issues.apache.org/jira/browse/IO-504">IO-504</a>)
+     * @param client client resource.
+     */
+    private static void closeClientQuietly(HtmlUnitClient client) {
+        if (client != null) {
+            try {
+                client.close();
+            } catch (IOException ignored) {}
+        }
     }
 
     /**

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
@@ -169,11 +169,7 @@ public class DeepGetPageIT {
     private static boolean isSameOrigin(URI uri1, URI uri2) {
         if (!uri1.getScheme().equals(uri2.getScheme())) {
             return false;
-        } else if (!uri1.getAuthority().equals(uri2.getAuthority())) {
-            return false;
-        } else {
-            return true;
-        }
+        } else return uri1.getAuthority().equals(uri2.getAuthority());
     }
 
 }

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/DeepGetPageIT.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 public class DeepGetPageIT {
 
     @ClassRule
-    public static CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/GetPageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/GetPageIT.java
@@ -37,7 +37,7 @@ public class GetPageIT {
     static CQClient adminPublish;
 
     @BeforeClass
-    public static void beforeClass() throws ClientException {
+    public static void beforeClass() {
         adminAuthor = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
         adminPublish = cqBaseClassRule.publishRule.getAdminClient(CQClient.class);
     }
@@ -45,10 +45,10 @@ public class GetPageIT {
     /**
      * Verifies that the homepage exists on author
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
      */
     @Test
-    public void testHomePageAuthor() throws Exception {
+    public void testHomePageAuthor() throws ClientException {
         // verify that page is present on author
         adminAuthor.doGet("/", 200);
     }
@@ -56,10 +56,10 @@ public class GetPageIT {
     /**
      * Verifies that the sites console exists on author
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
      */
     @Test
-    public void testSitesAuthor() throws Exception {
+    public void testSitesAuthor() throws ClientException {
         // verify that page is present on author
         adminAuthor.doGet("/sites.html", 200);
     }
@@ -67,10 +67,10 @@ public class GetPageIT {
     /**
      * Verifies that the assets console exists on author
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
      */
     @Test
-    public void testAssetsAuthor() throws Exception {
+    public void testAssetsAuthor() throws ClientException {
         // verify that page is present on author
         adminAuthor.doGet("/assets.html", 200);
     }
@@ -78,10 +78,10 @@ public class GetPageIT {
     /**
      * Verifies that the projects console exists on author
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
      */
     @Test
-    public void testProjectsAuthor() throws Exception {
+    public void testProjectsAuthor() throws ClientException {
         // verify that page is present on author
         adminAuthor.doGet("/projects.html", 200);
     }
@@ -89,12 +89,12 @@ public class GetPageIT {
     /**
      * Verifies that the homepage exists on publish
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
      *
      * TODO remove @Ignore once CQ-4265255 and NPR-29209 are fixed
      */
     @Test @Ignore
-    public void testHomePagePublish() throws Exception {
+    public void testHomePagePublish() throws ClientException {
         // verify that page is present on author
         adminPublish.doGet("/", 200);
     }

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/GetPageIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/GetPageIT.java
@@ -25,7 +25,7 @@ import org.junit.*;
 public class GetPageIT {
 
     @ClassRule
-    public static CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule, cqBaseClassRule.publishRule);

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/HtmlUnitClient.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/HtmlUnitClient.java
@@ -41,6 +41,7 @@ import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
 import org.w3c.dom.Node;
 
 import static org.junit.Assert.fail;
@@ -151,18 +152,18 @@ public class HtmlUnitClient extends CQClient {
     /**
      * Preemptively logins to the server
      * @param webClient web client to use for logging in.
-     * @throws ClientException if the request failed
+     * @throws TestingIOException if the request failed
      */
-    private void login(WebClient webClient) throws ClientException {
+    private void login(WebClient webClient) throws TestingIOException {
         URL loginUrl = null;
         try {
             loginUrl = getUrl("/bin/receive?sling:authRequestLogin=1").toURL();
             WebResponse response = webClient.loadWebResponse(new WebRequest(loginUrl));
             if (response.getStatusCode() != 200) {
-                throw new ClientException("Unable to login to server: [" + loginUrl + "]. Unexpected status: " + response.getStatusCode());
+                throw new TestingIOException("Unable to login to server: [" + loginUrl + "]. Unexpected status: " + response.getStatusCode());
             }
         } catch (IOException e) {
-            throw new ClientException("Unable to login to server: [" + loginUrl + "]", e);
+            throw new TestingIOException("Unable to login to server: [" + loginUrl + "]", e);
         }
     }
 

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/PageActionIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/PageActionIT.java
@@ -54,7 +54,7 @@ public class PageActionIT {
     private static final long RETRY_DELAY = 500;
 
     @ClassRule
-    public static CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.authorRule);

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/PageActionIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/PageActionIT.java
@@ -23,12 +23,15 @@ import com.adobe.cq.testing.junit.rules.Page;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
@@ -80,7 +83,12 @@ public class PageActionIT {
         // first create a page to be deleted
         LOGGER.info("Creating a page to delete.");
         client.waitExists(root.getPath(), TIMEOUT, RETRY_DELAY);
-        final String newPath = client.createPage("qatestdeletepage", pageTitle, root.getPath(), root.getTemplatePath()).getSlingPath();
+        String newPath;
+        try (SlingHttpResponse response = client.createPage("qatestdeletepage", pageTitle, root.getPath(), root.getTemplatePath())) {
+            newPath = response.getSlingPath();
+        } catch (IOException e) {
+            throw new TestingIOException("Exception while handling sling response (auto-closeable) of page creation", e);
+        }
 
         // make sure the page is created with'admin' account
         client.waitExists(newPath, TIMEOUT, RETRY_DELAY);
@@ -117,7 +125,12 @@ public class PageActionIT {
         // first create a page to copy
         LOGGER.info("Creating a page to copy.");
         String srcName = "qatestcopypage" + RandomStringUtils.random(10, true, true);
-        String originalPath = client.createPage(srcName, pageTitle, root.getPath(), root.getTemplatePath()).getSlingPath();
+        String originalPath;
+        try (SlingHttpResponse response = client.createPage(srcName, pageTitle, root.getPath(), root.getTemplatePath())) {
+            originalPath = response.getSlingPath();
+        } catch (IOException e) {
+            throw new TestingIOException("Exception while handling sling response (auto-closeable) of page creation", e);
+        }
 
         // make sure the page is created
         client.waitExists(originalPath, TIMEOUT, RETRY_DELAY);
@@ -164,7 +177,12 @@ public class PageActionIT {
         LOGGER.info("Creating a child page of root to act as our source folder.");
         String subFolderTitle = "QA Test Sub Folder" + RandomStringUtils.random(10, true, true);
         String subFolderName = "qatestsubfolder" + RandomStringUtils.random(10, true, true);
-        String subPage = client.createPage(subFolderName, subFolderTitle, root.getPath(),  root.getPath()).getSlingPath();
+        String subPage;
+        try (SlingHttpResponse response = client.createPage(subFolderName, subFolderTitle, root.getPath(),  root.getPath())) {
+            subPage = response.getSlingPath();
+        } catch (IOException e) {
+            throw new TestingIOException("Exception while handling sling response (auto-closeable) of page creation", e);
+        }
 
         // make sure sub folder exists
         client.waitExists(subPage, TIMEOUT, RETRY_DELAY);
@@ -173,7 +191,12 @@ public class PageActionIT {
         LOGGER.info("Creating the test page beneath the folder.");
         String pageTitle = "QA Test Move Page " + RandomStringUtils.random(10, true, true);
         String srcName = "qatestmovepage" + RandomStringUtils.random(10, true, true);
-        String originalPath = client.createPage(srcName, pageTitle, subPage, root.getTemplatePath()).getSlingPath();
+        String originalPath;
+        try (SlingHttpResponse response = client.createPage(srcName, pageTitle, subPage, root.getTemplatePath())) {
+            originalPath = response.getSlingPath();
+        } catch (IOException e) {
+            throw new TestingIOException("Exception while handling sling response (auto-closeable) of page creation", e);
+        }
 
         // make sure the page is created
         client.waitExists(originalPath, TIMEOUT, RETRY_DELAY);

--- a/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/PageActionIT.java
+++ b/wcm-smoke/src/main/java/com/adobe/cq/cloud/testing/it/wcm/smoke/PageActionIT.java
@@ -70,10 +70,12 @@ public class PageActionIT {
      *     <li>Verifies that the page got deleted using {@link CQClient#exists(String)}</li>
      * </ul>
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws InterruptedException if an error occurred
+     * @throws TimeoutException if an error occurred
      */
     @Test
-    public void testDeletePageAsAdmin() throws Exception {
+    public void testDeletePageAsAdmin() throws ClientException, InterruptedException, TimeoutException {
         LOGGER.info("Test to check that a page gets deleted properly.");
         final CQClient client = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
 
@@ -112,10 +114,12 @@ public class PageActionIT {
      *     <li>Checks if the original page is still intact with {@link CQClient#waitExists(String, long, long)}</li>
      * </ul>
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws InterruptedException if an error occurred
+     * @throws TimeoutException if an error occurred
      */
     @Test
-    public void testCopyPageToSameFolderAsAdmin() throws Exception {
+    public void testCopyPageToSameFolderAsAdmin() throws ClientException, InterruptedException, TimeoutException {
         LOGGER.info("Test to check that a page gets copied properly.");
         CQClient client = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
 
@@ -166,10 +170,12 @@ public class PageActionIT {
      *     <li>Checks if the original page is no longer available with {@link CQAssert#assertCQPageExistsWithTimeout}</li>
      * </ul>
      *
-     * @throws Exception if an error occurred
+     * @throws ClientException if an error occurred
+     * @throws InterruptedException if an error occurred
+     * @throws TimeoutException if an error occurred
      */
     @Test
-    public void testMovePageToSameFolderAsAdmin() throws Exception {
+    public void testMovePageToSameFolderAsAdmin() throws ClientException, InterruptedException, TimeoutException {
         LOGGER.info("Test to check that a page was moved successfully.");
         CQClient client = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
 

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
@@ -130,11 +130,13 @@ public class XfSmokeIT {
             ExperienceFragmentsClient.ExperienceFragment experienceFragment = xfClient.getExperienceFragment(xfPath);
             Assert.assertEquals("Description is incorrect", TEST_DESCRIPTION, experienceFragment.getDescription());
             Assert.assertEquals("Child page is creation failed", experienceFragment.getVariants().size(), 1);
+            Assert.assertNotNull("XF tags should not be null", experienceFragment.getTags());
             Assert.assertEquals("XF tags should be empty", experienceFragment.getTags().size(), 0);
             ExperienceFragmentsClient.ExperienceFragmentVariant masterVariant = experienceFragment.getVariants().get(0);
             Assert.assertEquals("First variation template is incorrect", masterVariant.getTemplateType(), predefinedTemplate);
             Assert.assertEquals("First variation title is incorrect", CREATE_VARIANT_TITLE, masterVariant.getTitle());
             Assert.assertTrue("First variation is not marked as master", masterVariant.isMasterVariant());
+            Assert.assertNotNull("Variant tags should not be null", masterVariant.getTags());
             Assert.assertEquals("Variant tags should contain at least one tag from the initial content", 1, masterVariant.getTags().size());
         }
     }
@@ -199,7 +201,8 @@ public class XfSmokeIT {
             Assert.assertEquals("Variant name", VARCREA_VARIANT_NAME, variant.getName());
             Assert.assertEquals("Variant description", TEST_DESCRIPTION, variant.getDescription());
             Assert.assertEquals("Variant template", template, variant.getTemplateType());
-            Assert.assertTrue("Variant tags", variant.getTags().size() == 0);
+            Assert.assertNotNull("Variant tags should not be null", variant.getTags());
+            Assert.assertEquals("Variant tags", 0, variant.getTags().size());
 
             adminXFClient.deletePage(new String[] { variantPath }, true, false);
         }
@@ -220,7 +223,7 @@ public class XfSmokeIT {
                 throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
             }
 
-            cleanupRule.addPath(authorXFClient.getParentXFPath(variantPath));
+            cleanupRule.addPath(ExperienceFragmentsClient.getParentXFPath(variantPath));
 
             authorXFClient.deleteXfVariant(variantPath, HttpStatus.SC_INTERNAL_SERVER_ERROR);
             Assert.assertTrue("Master variant should not be deleted", authorXFClient.exists(variantPath));
@@ -249,9 +252,8 @@ public class XfSmokeIT {
                 throw new TestingIOException("Exception while handling sling response (auto-closeable) of variant creation", e);
             }
 
-            authorXFClient.deleteXfVariant(variantPath, HttpStatus.SC_OK);
-            Assert.assertFalse("Variant should be deleted", authorXFClient.exists(variantPath));
+            adminXFClient.deleteXfVariant(variantPath, HttpStatus.SC_OK);
+            Assert.assertFalse("Variant should be deleted", adminXFClient.exists(variantPath));
         }
     }
-
 }

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
@@ -47,10 +47,10 @@ public class XfSmokeIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(XfSmokeIT.class);
 
-    private static CQAuthorPublishClassRule cqAuthorPublishClassRule = new CQAuthorPublishClassRule();
+    private static final CQAuthorPublishClassRule cqAuthorPublishClassRule = new CQAuthorPublishClassRule();
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(cqAuthorPublishClassRule);
+    public static final TestRule ruleChain = RuleChain.outerRule(cqAuthorPublishClassRule);
 
     @Rule
     public CQRule cqRule = new CQRule();

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
@@ -22,6 +22,8 @@ import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 import org.apache.http.HttpStatus;
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
 import org.apache.sling.testing.clients.util.poller.Polling;
 import org.junit.*;
 import org.junit.rules.RuleChain;
@@ -29,6 +31,7 @@ import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
@@ -84,9 +87,13 @@ public class XfSmokeIT {
 
     @Test
     public void testCreateXFInFolder() throws ClientException, TimeoutException, InterruptedException {
-        String folderLocation = cqAuthorPublishClassRule.authorRule.getAdminClient()
-                .createFolder(CREATE_FOLDER, CREATE_FOLDER, CREATE_XF_PARENT_PATH)
-                .getSlingPath();
+        String folderLocation;
+        try (SlingHttpResponse response = cqAuthorPublishClassRule.authorRule.getAdminClient()
+                .createFolder(CREATE_FOLDER, CREATE_FOLDER, CREATE_XF_PARENT_PATH)) {
+            folderLocation = response.getSlingPath();
+        } catch (IOException e) {
+            throw new TestingIOException("Exception while handling sling response (auto-closeable) of folder creation", e);
+        }
         cleanupRule.addPath(folderLocation);
         createExperienceFragments(folderLocation);
     }
@@ -101,14 +108,18 @@ public class XfSmokeIT {
             if (predefinedTemplate == XF_TEMPLATE.CUSTOM)
                 continue;
 
-            String xfPath = xfClient
+            String xfPath;
+            try (SlingHttpResponse response = xfClient
                     .experienceFragmentBuilder(CREATE_XF_TITLE, CREATE_VARIANT_TITLE, predefinedTemplate)
                     .withParentPath(parentPath)
                     .withXFName(CREATE_XF_NAME)
                     .withVariantName(CREATE_VARIANT_NAME)
                     .withXFDescription(TEST_DESCRIPTION)
-                    .create(HttpStatus.SC_CREATED)
-                    .getSlingParentLocation();
+                    .create(HttpStatus.SC_CREATED)) {
+                xfPath = response.getSlingParentLocation();
+            } catch (IOException e) {
+                throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
+            }
             Assert.assertTrue("Parent path is incorrect", xfPath.startsWith(parentPath));
             cleanupRule.addPath(xfPath);
 
@@ -135,9 +146,12 @@ public class XfSmokeIT {
             if (predefinedTemplate == XF_TEMPLATE.CUSTOM)
                 continue;
 
-            String xfLocation = client
-                    .createExperienceFragment(DELETE_XF_TITLE, DELETE_VARIANT_TITLE, predefinedTemplate)
-                    .getSlingParentLocation();
+            String xfLocation;
+            try (SlingHttpResponse response = client.createExperienceFragment(DELETE_XF_TITLE, DELETE_VARIANT_TITLE, predefinedTemplate)) {
+                xfLocation = response.getSlingParentLocation();
+            } catch (IOException e) {
+                throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
+            }
             cleanupRule.addPath(xfLocation);
 
             client.deleteExperienceFragment(xfLocation, false, HttpStatus.SC_PRECONDITION_FAILED);
@@ -152,19 +166,26 @@ public class XfSmokeIT {
     public void createXFVariantTest() throws ClientException {
         final CQClient adminAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
         final ExperienceFragmentsClient adminXFClient = adminAuthor.adaptTo(ExperienceFragmentsClient.class);
-        String xfPath = adminXFClient
-                .createExperienceFragment(VARCREA_XF_TITLE, VARCREA_MASTER_VARIANT_TITLE, XF_TEMPLATE.WEB)
-                .getSlingParentLocation();
+        String xfPath;
+        try (SlingHttpResponse response = adminXFClient.createExperienceFragment(VARCREA_XF_TITLE, VARCREA_MASTER_VARIANT_TITLE, XF_TEMPLATE.WEB)) {
+            xfPath = response.getSlingParentLocation();
+        } catch (IOException e) {
+            throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
+        }
         cleanupRule.addPath(xfPath);
 
         for(XF_TEMPLATE template : XF_TEMPLATE.values()) {
             if (template == XF_TEMPLATE.CUSTOM) continue;
 
-            String variantPath = adminXFClient.xfVariantBuilder(xfPath, template, VARCREA_VARIANT_TITLE)
-                .withName(VARCREA_VARIANT_NAME)
-                .withDescription(TEST_DESCRIPTION)
-                .create()
-                .getSlingLocation();
+            String variantPath;
+            try (SlingHttpResponse response = adminXFClient.xfVariantBuilder(xfPath, template, VARCREA_VARIANT_TITLE)
+                    .withName(VARCREA_VARIANT_NAME)
+                    .withDescription(TEST_DESCRIPTION)
+                    .create()) {
+                variantPath = response.getSlingLocation();
+            } catch (IOException e) {
+                throw new TestingIOException("Exception while handling sling response (auto-closeable) of variant creation", e);
+            }
 
             ExperienceFragmentsClient.ExperienceFragmentVariant variant = adminXFClient.getXFVariant(variantPath);
 
@@ -192,9 +213,12 @@ public class XfSmokeIT {
         for(XF_TEMPLATE template : XF_TEMPLATE.values()) {
             if(template == XF_TEMPLATE.CUSTOM) continue;
 
-            String variantPath = authorXFClient
-                    .createExperienceFragment(VARDEL_XF_TITLE, VARDEL_MASTER_VARIANT_TITLE, template)
-                    .getSlingLocation();
+            String variantPath;
+            try (SlingHttpResponse response = authorXFClient.createExperienceFragment(VARDEL_XF_TITLE, VARDEL_MASTER_VARIANT_TITLE, template)) {
+                variantPath = response.getSlingLocation();
+            } catch (IOException e) {
+                throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
+            }
 
             cleanupRule.addPath(authorXFClient.getParentXFPath(variantPath));
 
@@ -205,20 +229,25 @@ public class XfSmokeIT {
 
     @Test
     public void variantDelete() throws ClientException {
-        final CQClient authorAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
-        final ExperienceFragmentsClient authorXFClient = authorAuthor.adaptTo(ExperienceFragmentsClient.class);
-
-        String xfPath = authorXFClient
-                .createExperienceFragment(VARDEL_XF_TITLE, VARDEL_MASTER_VARIANT_TITLE, XF_TEMPLATE.WEB)
-                .getSlingParentLocation();
-
+        final CQClient adminAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
+        final ExperienceFragmentsClient adminXFClient = adminAuthor.adaptTo(ExperienceFragmentsClient.class);
+        String xfPath;
+        try (SlingHttpResponse response = adminXFClient.createExperienceFragment(VARDEL_XF_TITLE, VARDEL_MASTER_VARIANT_TITLE, XF_TEMPLATE.WEB)) {
+            xfPath = response.getSlingParentLocation();
+        } catch (IOException e) {
+            throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
+        }
         cleanupRule.addPath(xfPath);
 
         for(XF_TEMPLATE template : XF_TEMPLATE.values()) {
             if (template == XF_TEMPLATE.CUSTOM) continue;
 
-            String variantPath = authorXFClient.createXfVariant(xfPath, template, VARDEL_VARIANT_TITLE)
-                                               .getSlingLocation();
+            String variantPath;
+            try (SlingHttpResponse response = adminXFClient.createXfVariant(xfPath, template, VARDEL_VARIANT_TITLE)) {
+                variantPath = response.getSlingLocation();
+            } catch (IOException e) {
+                throw new TestingIOException("Exception while handling sling response (auto-closeable) of variant creation", e);
+            }
 
             authorXFClient.deleteXfVariant(variantPath, HttpStatus.SC_OK);
             Assert.assertFalse("Variant should be deleted", authorXFClient.exists(variantPath));

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/rules/CleanupRule.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/rules/CleanupRule.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 public class CleanupRule extends ExternalResource {
-    public ThreadLocal<List<String>> toDelete = ThreadLocal.withInitial(() -> new ArrayList<>(15));
+    private static final ThreadLocal<List<String>> toDelete = ThreadLocal.withInitial(() -> new ArrayList<>(15));
     private final Instance rule;
     private final long timeout;
     private final long delay;

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/rules/CleanupRule.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/rules/CleanupRule.java
@@ -51,7 +51,7 @@ public class CleanupRule extends ExternalResource {
 
     @Override
     protected void after() {
-        toDelete.get().stream().forEach((path) -> {
+        toDelete.get().forEach((path) -> {
             try {
                 new Polling(() -> {
                     rule.getAdminClient().deletePath(path);

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/rules/CleanupRule.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/rules/CleanupRule.java
@@ -21,6 +21,7 @@ import org.junit.rules.ExternalResource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 public class CleanupRule extends ExternalResource {
     public ThreadLocal<List<String>> toDelete = ThreadLocal.withInitial(() -> new ArrayList<>(15));
@@ -56,8 +57,7 @@ public class CleanupRule extends ExternalResource {
                     rule.getAdminClient().deletePath(path);
                     return rule.getAdminClient().exists(path);
                 }).poll(timeout, delay);
-            } catch (Throwable t) {
-            }
+            } catch (InterruptedException | TimeoutException | RuntimeException ignored) {}
         });
     }
 }


### PR DESCRIPTION
## Description

Improvements and refactoring to eliminate critical and blocking sonar issues and decrease the total amount of sonar issues within the aem-test-samples.

The following changes were conducted:
- Replacement of unclosed resources with try-with-resource pattern or added a manual close in the finally block.
- Restricting access to fields and parameters to the needed scope and/or making them immutable if appropriate.
- More explicit exception handling in places where only generic throwables or exceptions were used. In cases where it was not immediately evident whether catching runtime exceptions should also be taken into account, the latter were also retained so as not to change the existing functionality.
- Reduction of consecutive log and throw statements. If the content of both is identical, complete removal of the obsolete logging. In justified cases, suppression of the sonar warning with appropriate labeling.
- Replacement of deprecated api usages with a newer or alternative implementation.
- General cleanup of warnings and simplification of some statements while retaining functionality.

## Screenshots

Before:
![sonar_before](https://user-images.githubusercontent.com/28481491/198988394-8dce3c49-8942-4d23-9afc-8b7d58b14434.png)

After:
![sonar_after](https://user-images.githubusercontent.com/28481491/198988425-9d307c06-2814-411f-af7a-04afb2462113.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
