### PR TITLE
SITES-9992 - make tests in XfSmokeIT more resilient

### DIFF
--- a/xf-smoke/pom.xml
+++ b/xf-smoke/pom.xml
@@ -235,5 +235,11 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
@@ -257,7 +257,7 @@ public class XfSmokeIT {
             }
 
             await().untilAsserted(() -> {
-                Assert.assertTrue("Master variant should exit", authorXFClient.exists(variantPath));
+                Assert.assertTrue("Master variant should exist", authorXFClient.exists(variantPath));
             });
 
             cleanupRule.addPath(ExperienceFragmentsClient.getParentXFPath(variantPath));

--- a/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
+++ b/xf-smoke/src/main/java/com/adobe/cq/cloud/testing/it/xf/smoke/XfSmokeIT.java
@@ -18,24 +18,36 @@ package com.adobe.cq.cloud.testing.it.xf.smoke;
 import com.adobe.cq.cloud.testing.it.xf.smoke.rules.CleanupRule;
 import com.adobe.cq.testing.client.CQClient;
 import com.adobe.cq.testing.client.ExperienceFragmentsClient;
+import com.adobe.cq.testing.client.ExperienceFragmentsClient.ExperienceFragment;
+import com.adobe.cq.testing.client.ExperienceFragmentsClient.ExperienceFragmentVariant;
+import com.adobe.cq.testing.client.ExperienceFragmentsClient.XF_TEMPLATE;
 import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
+
 import org.apache.http.HttpStatus;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
 import org.apache.sling.testing.clients.exceptions.TestingIOException;
-import org.apache.sling.testing.clients.util.poller.Polling;
-import org.junit.*;
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.awaitility.pollinterval.FibonacciPollInterval;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.adobe.cq.testing.client.ExperienceFragmentsClient.XF_TEMPLATE;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Test Delete Experience Fragment Operation
@@ -65,20 +77,26 @@ public class XfSmokeIT {
     private static final String CREATE_XF_TITLE = "XfCreateIT Test Experience Fragment";
     private static final String CREATE_XF_NAME = "test-xf-name";
     private static final String CREATE_VARIANT_TITLE = "XfCreateIT Test Experience Fragment Variant";
-    private static final String CREATE_VARIANT_NAME ="test-experience-fragment-name";
+    private static final String CREATE_VARIANT_NAME = "test-experience-fragment-name";
 
     private static final String DELETE_XF_TITLE = "DeleteXFTest";
     private static final String DELETE_VARIANT_TITLE = "Test Experience Fragment Variant";
 
     private static final String VARCREA_XF_TITLE = "VariantCreateTest";
     private static final String VARCREA_VARIANT_TITLE = "Test Experience Fragment Variant";
-    private static final String VARCREA_VARIANT_NAME ="test-experience-fragment-name";
+    private static final String VARCREA_VARIANT_NAME = "test-experience-fragment-name";
     private static final String VARCREA_MASTER_VARIANT_TITLE = "Master " + VARCREA_VARIANT_TITLE;
 
     private static final String VARDEL_XF_TITLE = "VariantDeleteTest";
     private static final String VARDEL_VARIANT_TITLE = "Test Experience Fragment Variant";
     private static final String VARDEL_MASTER_VARIANT_TITLE = "Master " + VARDEL_VARIANT_TITLE;
 
+    @BeforeClass
+    public static void setupAwait() {
+        Awaitility.setDefaultPollInterval(new FibonacciPollInterval(1, TimeUnit.SECONDS));
+        Awaitility.setDefaultPollDelay(Durations.TWO_HUNDRED_MILLISECONDS);
+        Awaitility.setDefaultTimeout(Durations.ONE_MINUTE);
+    }
 
     @Test
     public void testCreateExperienceFragment() throws ClientException, TimeoutException, InterruptedException {
@@ -123,11 +141,10 @@ public class XfSmokeIT {
             Assert.assertTrue("Parent path is incorrect", xfPath.startsWith(parentPath));
             cleanupRule.addPath(xfPath);
 
-            // Wait for experience Fragment to be created
-            new Polling(() -> xfClient.exists(xfPath)).poll(TIMEOUT, RETRY_DELAY);
-
-            Assert.assertTrue("Experience Fragment was not created", xfClient.exists(xfPath));
-            ExperienceFragmentsClient.ExperienceFragment experienceFragment = xfClient.getExperienceFragment(xfPath);
+            await().ignoreException(ClientException.class)
+                    .untilAsserted(() -> Assert.assertTrue("Experience Fragment is created", xfClient.exists(xfPath)));
+            ExperienceFragment experienceFragment =
+                    await().ignoreException(ClientException.class).until(() -> xfClient.getExperienceFragment(xfPath), Objects::nonNull);
             Assert.assertEquals("Description is incorrect", TEST_DESCRIPTION, experienceFragment.getDescription());
             Assert.assertEquals("Child page is creation failed", experienceFragment.getVariants().size(), 1);
             Assert.assertNotNull("XF tags should not be null", experienceFragment.getTags());
@@ -145,8 +162,9 @@ public class XfSmokeIT {
     public void deleteExperienceFragmentTest() throws ClientException {
         final ExperienceFragmentsClient client = cqAuthorPublishClassRule.authorRule.getAdminClient(ExperienceFragmentsClient.class);
         for (XF_TEMPLATE predefinedTemplate : XF_TEMPLATE.values()) {
-            if (predefinedTemplate == XF_TEMPLATE.CUSTOM)
+            if (predefinedTemplate == XF_TEMPLATE.CUSTOM) {
                 continue;
+            }
 
             String xfLocation;
             try (SlingHttpResponse response = client.createExperienceFragment(DELETE_XF_TITLE, DELETE_VARIANT_TITLE, predefinedTemplate)) {
@@ -156,11 +174,15 @@ public class XfSmokeIT {
             }
             cleanupRule.addPath(xfLocation);
 
-            client.deleteExperienceFragment(xfLocation, false, HttpStatus.SC_PRECONDITION_FAILED);
-            Assert.assertTrue("Experience Fragment should not be deleted", client.exists(xfLocation));
+            await().untilAsserted(() -> {
+                client.deleteExperienceFragment(xfLocation, false, HttpStatus.SC_PRECONDITION_FAILED);
+                Assert.assertTrue("Experience Fragment should not be deleted", client.exists(xfLocation));
+            });
 
-            client.deleteExperienceFragment(xfLocation, HttpStatus.SC_OK);
-            Assert.assertFalse("Experience Fragment should be deleted", client.exists(xfLocation));
+            await().untilAsserted(() -> {
+                client.deleteExperienceFragment(xfLocation, HttpStatus.SC_OK);
+                Assert.assertFalse("Experience Fragment should be deleted", client.exists(xfLocation));
+            });
         }
     }
 
@@ -169,15 +191,18 @@ public class XfSmokeIT {
         final CQClient adminAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
         final ExperienceFragmentsClient adminXFClient = adminAuthor.adaptTo(ExperienceFragmentsClient.class);
         String xfPath;
-        try (SlingHttpResponse response = adminXFClient.createExperienceFragment(VARCREA_XF_TITLE, VARCREA_MASTER_VARIANT_TITLE, XF_TEMPLATE.WEB)) {
+        try (SlingHttpResponse response =
+                adminXFClient.createExperienceFragment(VARCREA_XF_TITLE, VARCREA_MASTER_VARIANT_TITLE, XF_TEMPLATE.WEB)) {
             xfPath = response.getSlingParentLocation();
         } catch (IOException e) {
             throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
         }
         cleanupRule.addPath(xfPath);
 
-        for(XF_TEMPLATE template : XF_TEMPLATE.values()) {
-            if (template == XF_TEMPLATE.CUSTOM) continue;
+        for (XF_TEMPLATE template : XF_TEMPLATE.values()) {
+            if (template == XF_TEMPLATE.CUSTOM) {
+                continue;
+            }
 
             String variantPath;
             try (SlingHttpResponse response = adminXFClient.xfVariantBuilder(xfPath, template, VARCREA_VARIANT_TITLE)
@@ -189,22 +214,27 @@ public class XfSmokeIT {
                 throw new TestingIOException("Exception while handling sling response (auto-closeable) of variant creation", e);
             }
 
-            ExperienceFragmentsClient.ExperienceFragmentVariant variant = adminXFClient.getXFVariant(variantPath);
+            ExperienceFragmentVariant variant =
+                    await().ignoreException(ClientException.class).until(() -> adminXFClient.getXFVariant(variantPath), Objects::nonNull);
 
-            Assert.assertFalse("Variant should not be master", variant.isMasterVariant());
-            Assert.assertFalse("Variant should not be live copy", variant.isLiveCopy());
-            Assert.assertEquals("Is social variant", template.isSocialTemplate(), variant.isSocialVariant());
-            Assert.assertFalse("Variant should not be a live copy", variant.isLiveCopy());
-            Assert.assertEquals("Variant type", template.variantType(), variant.getVariantType());
+            await().ignoreException(ClientException.class).untilAsserted(() -> {
+                Assert.assertFalse("Variant should not be master", variant.isMasterVariant());
+                Assert.assertFalse("Variant should not be live copy", variant.isLiveCopy());
+                Assert.assertEquals("Is social variant", template.isSocialTemplate(), variant.isSocialVariant());
+                Assert.assertFalse("Variant should not be a live copy", variant.isLiveCopy());
+                Assert.assertEquals("Variant type", template.variantType(), variant.getVariantType());
 
-            Assert.assertEquals("Variant title", VARCREA_VARIANT_TITLE, variant.getTitle());
-            Assert.assertEquals("Variant name", VARCREA_VARIANT_NAME, variant.getName());
-            Assert.assertEquals("Variant description", TEST_DESCRIPTION, variant.getDescription());
-            Assert.assertEquals("Variant template", template, variant.getTemplateType());
-            Assert.assertNotNull("Variant tags should not be null", variant.getTags());
-            Assert.assertEquals("Variant tags", 0, variant.getTags().size());
+                Assert.assertEquals("Variant title", VARCREA_VARIANT_TITLE, variant.getTitle());
+                Assert.assertEquals("Variant name", VARCREA_VARIANT_NAME, variant.getName());
+                Assert.assertEquals("Variant description", TEST_DESCRIPTION, variant.getDescription());
+                Assert.assertEquals("Variant template", template, variant.getTemplateType());
+                Assert.assertNotNull("Variant tags should not be null", variant.getTags());
+                Assert.assertEquals("Variant tags", 0, variant.getTags().size());
+            });
 
-            adminXFClient.deletePage(new String[] { variantPath }, true, false);
+            adminXFClient.deletePage(new String[] {
+                    variantPath
+            }, true, false);
         }
     }
 
@@ -213,20 +243,29 @@ public class XfSmokeIT {
         final CQClient adminAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
         final ExperienceFragmentsClient authorXFClient = adminAuthor.adaptTo(ExperienceFragmentsClient.class);
 
-        for(XF_TEMPLATE template : XF_TEMPLATE.values()) {
-            if(template == XF_TEMPLATE.CUSTOM) continue;
+        for (XF_TEMPLATE template : XF_TEMPLATE.values()) {
+            if (template == XF_TEMPLATE.CUSTOM) {
+                continue;
+            }
 
             String variantPath;
-            try (SlingHttpResponse response = authorXFClient.createExperienceFragment(VARDEL_XF_TITLE, VARDEL_MASTER_VARIANT_TITLE, template)) {
+            try (SlingHttpResponse response =
+                    authorXFClient.createExperienceFragment(VARDEL_XF_TITLE, VARDEL_MASTER_VARIANT_TITLE, template)) {
                 variantPath = response.getSlingLocation();
             } catch (IOException e) {
                 throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
             }
 
+            await().untilAsserted(() -> {
+                Assert.assertTrue("Master variant should exit", authorXFClient.exists(variantPath));
+            });
+
             cleanupRule.addPath(ExperienceFragmentsClient.getParentXFPath(variantPath));
 
             authorXFClient.deleteXfVariant(variantPath, HttpStatus.SC_INTERNAL_SERVER_ERROR);
-            Assert.assertTrue("Master variant should not be deleted", authorXFClient.exists(variantPath));
+            await().untilAsserted(() -> {
+                Assert.assertTrue("Master variant should not be deleted", authorXFClient.exists(variantPath));
+            });
         }
     }
 
@@ -235,15 +274,17 @@ public class XfSmokeIT {
         final CQClient adminAuthor = cqAuthorPublishClassRule.authorRule.getAdminClient(CQClient.class);
         final ExperienceFragmentsClient adminXFClient = adminAuthor.adaptTo(ExperienceFragmentsClient.class);
         String xfPath;
-        try (SlingHttpResponse response = adminXFClient.createExperienceFragment(VARDEL_XF_TITLE, VARDEL_MASTER_VARIANT_TITLE, XF_TEMPLATE.WEB)) {
+        try (SlingHttpResponse response =
+                adminXFClient.createExperienceFragment(VARDEL_XF_TITLE, VARDEL_MASTER_VARIANT_TITLE, XF_TEMPLATE.WEB)) {
             xfPath = response.getSlingParentLocation();
         } catch (IOException e) {
             throw new TestingIOException("Exception while handling sling response (auto-closeable) of fragment creation", e);
         }
         cleanupRule.addPath(xfPath);
 
-        for(XF_TEMPLATE template : XF_TEMPLATE.values()) {
-            if (template == XF_TEMPLATE.CUSTOM) continue;
+        for (XF_TEMPLATE template : XF_TEMPLATE.values()) {
+            if (template == XF_TEMPLATE.CUSTOM)
+                continue;
 
             String variantPath;
             try (SlingHttpResponse response = adminXFClient.createXfVariant(xfPath, template, VARDEL_VARIANT_TITLE)) {
@@ -252,8 +293,14 @@ public class XfSmokeIT {
                 throw new TestingIOException("Exception while handling sling response (auto-closeable) of variant creation", e);
             }
 
+            await().untilAsserted(() -> {
+                Assert.assertTrue("Variant should exist", adminXFClient.exists(variantPath));
+            });
+
             adminXFClient.deleteXfVariant(variantPath, HttpStatus.SC_OK);
-            Assert.assertFalse("Variant should be deleted", adminXFClient.exists(variantPath));
+            await().untilAsserted(() -> {
+                Assert.assertFalse("Variant should be deleted", adminXFClient.exists(variantPath));
+            });
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
There have been added await checks for the xf related content since this content may not be available immediately on a cloud instance. These checks are used also for similar tests in the https://git.corp.adobe.com/CQ/experience-fragments repository.

## Related Issue
SITES-9992

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I tested them against local cloud sdk instances (author + publisher).
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
