### PR TITLE
SITES-11760 - Add persisted query liveness probe

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
@@ -25,7 +25,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class PersistedQueryServletIT {
+public class PersistedQueryIT {
 
     @ClassRule
     public static final CQPublishClassRule cqBaseClassRule = new CQPublishClassRule();
@@ -45,7 +45,7 @@ public class PersistedQueryServletIT {
      * @throws ClientException in case if error is occurred
      */
     @Test
-    public void testPersistedQueryListIT() throws ClientException {
+    public void testPersistedQueryEndpointAccessible() throws ClientException {
         adminPublish.doGet("/graphql/execute.json", 204);
     }
 }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
@@ -19,6 +19,7 @@ package com.adobe.cq.cloud.testing.it.smoke;
 import com.adobe.cq.testing.client.CQClient;
 import com.adobe.cq.testing.junit.rules.CQPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
+import org.apache.http.HttpStatus;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.util.poller.Polling;
 import org.junit.BeforeClass;
@@ -49,20 +50,15 @@ public class PersistedQueryIT {
     /**
      * Verifies GET request to persisted query servlet is successful
      *
-     * @throws ClientException in case if error is occurred
+     * @throws InterruptedException in case if error is occurred
+     * @throws TimeoutException in case if error is occurred
      */
     @Test
-    public void testPersistedQueryEndpointAccessible() throws ClientException, InterruptedException, TimeoutException {
+    public void testPersistedQueryEndpointAccessible() throws InterruptedException, TimeoutException {
         new Polling() {
             @Override
             public Boolean call() throws Exception {
-                try {
-                    anonymous.doGet("/graphql/execute.json", 204);
-                    return true;
-                } catch (ClientException ce) {
-                    // do nothing
-                    return false;
-                }
+                return HttpStatus.SC_NO_CONTENT == anonymous.doGet("/graphql/execute.json").getStatusLine().getStatusCode();
             }
         }.poll(TIMEOUT, DELAY);
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
@@ -2,7 +2,7 @@
  * ADOBE CONFIDENTIAL
  * ___________________
  *
- * Copyright 2021 Adobe
+ * Copyright 2023 Adobe
  * All Rights Reserved.
  *
  * NOTICE: All information contained herein is, and remains
@@ -20,7 +20,6 @@ import com.adobe.cq.testing.client.CQClient;
 import com.adobe.cq.testing.junit.rules.CQPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 import org.apache.http.HttpStatus;
-import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.util.poller.Polling;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -37,28 +36,28 @@ public class PersistedQueryIT {
 
     @ClassRule
     public static final CQPublishClassRule cqBaseClassRule = new CQPublishClassRule();
-    static CQClient anonymous;
+    static CQClient publishClient;
 
     @Rule
     public CQRule cqBaseRule = new CQRule(cqBaseClassRule.publishRule);
 
     @BeforeClass
     public static void beforeClass() {
-        anonymous = cqBaseClassRule.publishRule.getClient(CQClient.class, null, null);
+        publishClient = cqBaseClassRule.publishRule.getAdminClient(CQClient.class);
     }
 
     /**
      * Verifies GET request to persisted query servlet is successful
      *
      * @throws InterruptedException in case if error is occurred
-     * @throws TimeoutException in case if error is occurred
+     * @throws TimeoutException     in case if error is occurred
      */
     @Test
     public void testPersistedQueryEndpointAccessible() throws InterruptedException, TimeoutException {
         new Polling() {
             @Override
             public Boolean call() throws Exception {
-                return HttpStatus.SC_NO_CONTENT == anonymous.doGet("/graphql/execute.json").getStatusLine().getStatusCode();
+                return HttpStatus.SC_NO_CONTENT == publishClient.doGet("/graphql/execute.json").getStatusLine().getStatusCode();
             }
         }.poll(TIMEOUT, DELAY);
     }

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
@@ -43,6 +43,7 @@ public class PersistedQueryIT {
 
     @BeforeClass
     public static void beforeClass() {
+        // todo: switch to anonymous client, once CQ-4355073 is addressed
         publishClient = cqBaseClassRule.publishRule.getAdminClient(CQClient.class);
     }
 

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryServletIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryServletIT.java
@@ -1,0 +1,51 @@
+/*************************************************************************
+ * ADOBE CONFIDENTIAL
+ * ___________________
+ *
+ * Copyright 2021 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains
+ * the property of Adobe and its suppliers, if any. The intellectual
+ * and technical concepts contained herein are proprietary to Adobe
+ * and its suppliers and are protected by all applicable intellectual
+ * property laws, including trade secret and copyright laws.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe.
+ **************************************************************************/
+package com.adobe.cq.cloud.testing.it.smoke;
+
+import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.rules.CQPublishClassRule;
+import com.adobe.cq.testing.junit.rules.CQRule;
+import org.apache.sling.testing.clients.ClientException;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PersistedQueryServletIT {
+
+    @ClassRule
+    public static final CQPublishClassRule cqBaseClassRule = new CQPublishClassRule();
+    static CQClient adminPublish;
+
+    @Rule
+    public CQRule cqBaseRule = new CQRule(cqBaseClassRule.publishRule);
+
+    @BeforeClass
+    public static void beforeClass() {
+        adminPublish = cqBaseClassRule.publishRule.getAdminClient(CQClient.class);
+    }
+
+    /**
+     * Verifies GET request to persisted query servlet is successful
+     *
+     * @throws ClientException in case if error is occurred
+     */
+    @Test
+    public void testPersistedQueryListIT() throws ClientException {
+        adminPublish.doGet("/graphql/execute.json", 204);
+    }
+}


### PR DESCRIPTION
A health check for PersistedQueryServlet via dispatcher to see if it can be reached.

## Description

Send an GET request to **/graphql/execute.json** endpoint and check it's responding with HTTP 204

## Motivation and Context

Content delivery with persisted queries sometimes get broken due to invalid dispatcher configuration.
This test should detect such situation.

## How Has This Been Tested?

Against local instance, according to README

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

All new and existing tests passed except PublishEndToEndIT.testActivateAndDeactivate in spite of locally configured replication. 