### PR TITLE
CQ-4353362: disable color output when running cypress to have clean logs

### DIFF
--- a/ui-cypress/test-module/run.sh
+++ b/ui-cypress/test-module/run.sh
@@ -21,5 +21,7 @@ Xvfb :99 -screen 0 1280x1024x24 -ac -nolisten tcp -nolisten unix &
 export DISPLAY=:99
 echo 'checking Xvfb'
 ps aux | grep Xvfb
+# disable color output when running Cypress
+export NO_COLOR=1
 # execute tests
 npm test


### PR DESCRIPTION
Cypress by default has a multi-color output on the console for interactive usage.
The related control characters are stored in the created log files and "mess up" the log file.
By setting an environment variable before triggering Cypress, we can disable the color output for the execution via EaaS

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
