### PR TITLE
CQ-4353361: junit reporter did overwrite the XML reports during execution

### DIFF
--- a/ui-cypress/test-module/reporter.config.js
+++ b/ui-cypress/test-module/reporter.config.js
@@ -19,6 +19,6 @@ const reportsPath = process.env.REPORTS_PATH || 'cypress/results'
 module.exports = {
   reporterEnabled: 'spec, mocha-junit-reporter',
   mochaJunitReporterReporterOptions: {
-    mochaFile: `${reportsPath}/output.xml`
+    mochaFile: `${reportsPath}/output.[hash].xml`
   },
 }


### PR DESCRIPTION
CQ-4353361

## Description

The spec reporter is handling all report suites as expected.
Though the junit-mocha-reporter did use the same XML output file for each test suite and during execution in a pipeline only the last test suite was included causing test failures not to be tracked correctly by the pipeline.

## Related Issue

CQ-4353361

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
