### PR TITLE
[SITES-9338] Use the content-authors built-in group for test

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/CreatePageAsAuthorUserIT.java
@@ -19,7 +19,6 @@ import com.adobe.cq.testing.client.CQClient;
 import com.adobe.cq.testing.junit.rules.CQAuthorClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 import com.adobe.cq.testing.junit.rules.Page;
-import com.adobe.cq.testing.junit.rules.TemporaryContentAuthorGroup;
 import com.adobe.cq.testing.junit.rules.TemporaryUser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -55,13 +54,11 @@ public class CreatePageAsAuthorUserIT {
 
     // Create a random page so the test site is initialized properly.
     private final Page temporaryPage = new Page(cqBaseClassRule.authorRule);
-    
-    private static final TemporaryContentAuthorGroup groupRule = new TemporaryContentAuthorGroup(cqBaseClassRule.authorRule::getAdminClient);
 
-    @Rule
-    public TestRule cqRuleChainGroup = RuleChain.outerRule(cqBaseRule).around(groupRule);
+    private static final String CONTENT_AUTHORS_GROUP = "content-authors";
 
-    private static final TemporaryUser userRule = new TemporaryUser(cqBaseClassRule.authorRule::getAdminClient, groupRule.getGroupName());
+    private static final TemporaryUser userRule = new TemporaryUser(cqBaseClassRule.authorRule::getAdminClient,
+            CONTENT_AUTHORS_GROUP);
 
     @Rule
     public TestRule cqRuleChain = RuleChain.outerRule(cqBaseRule).around(temporaryPage).around(userRule);


### PR DESCRIPTION
## Description

CreatePageAsAuthorUserIT.testCreatePageAsAuthor test fails sometimes on the group creation phase. Using the built-in content-authors group for this test.

## Related Issue

## Motivation and Context

This test fails sometimes when trying to create the temporary group needed as a prerequisite for the test.
Removing this flakiness by using the built-in content-authors group. 

## How Has This Been Tested?

Running this test against the local sdk.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
