### PR TITLE
CQ-4353919: New smoke test for AEM error handler

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ErrorHandlerIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ErrorHandlerIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adobe.cq.cloud.testing.it.smoke;
+
+import com.adobe.cq.testing.client.CQClient;
+import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
+import org.apache.sling.testing.clients.ClientException;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * This test class is protecting from flawed AEM error handler implementations that are not returning 404s in case
+ * of page not found.
+ */
+public class ErrorHandlerIT {
+
+    private static CQClient adminAuthor;
+    private static CQClient adminPublish;
+
+
+    /**
+     * Initializing author and publish class rules.
+     */
+    @ClassRule
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+
+    /**
+     * Initialize new author and publish clients for use by the tests.
+     */
+    @BeforeClass
+    public static void beforeClass() {
+        adminAuthor = cqBaseClassRule.authorRule.getAdminClient(CQClient.class);
+        adminPublish = cqBaseClassRule.publishRule.getAdminClient(CQClient.class);
+    }
+
+    /**
+     * Ensure the author returns a 404 when requesting a non-exising page.
+     *
+     * @throws ClientException
+     */
+    @Test
+    public void testAuthorResponseCode404() throws ClientException {
+        adminAuthor.doGet("/content/does/not/exist.html", 404);
+    }
+
+    /**
+     * Ensure the publish returns a 404 when requesting a non-existing page.
+     *
+     * @throws ClientException
+     */
+    @Test
+    public void testPublishResponseCode404() throws ClientException {
+        adminPublish.doGet("/content/does/not/exist.html", 404);
+    }
+}


### PR DESCRIPTION
## Description

A new smoke IT test to ensure 404 is returned on non-existing resources. Goal is to protect from customers with flawed custom AEM error handler implementations that return 200 in that case. 

## Related Issue
CQ-4353919

## Motivation and Context

## How Has This Been Tested?

* Running smoke test locally against an AEMCS
* Deployed artifact com.adobe.cq.cloud:com.adobe.cq.cloud.testing.it.smoke:0.20.4-SNAPSHOT 
* Running smoke tests with this SNAPSHOT release using EAAS prod and EAAS CLI


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
