### PR TITLE
CQ-4353919: ErrorHandlerIT improvemnts

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ErrorHandlerIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/ErrorHandlerIT.java
@@ -40,6 +40,7 @@ public class ErrorHandlerIT {
     private static CQClient adminPublish;
 
 
+    private static final String testPage = "/content/test-site/missingpage_%s";
     private static final String testErrorMessage = new StringBuilder()
             .append("Error handler test on %s failed. Getting a %s response code when requesting the non-existing resource '%s'.")
             .append(System.lineSeparator())
@@ -73,7 +74,7 @@ public class ErrorHandlerIT {
      */
     @Test
     public void testAuthorResponseCode404() throws ClientException {
-        String path = "/content/test-site/" + UUID.randomUUID();
+        String path = String.format(testPage, UUID.randomUUID());
         try {
             adminAuthor.doGet(path, 404);
         } catch (ClientException e) {
@@ -89,7 +90,7 @@ public class ErrorHandlerIT {
      */
     @Test
     public void testPublishResponseCode404() throws ClientException {
-        String path = "/content/test-site/" + UUID.randomUUID();
+        String path = String.format(testPage, UUID.randomUUID());
         try {
             adminPublish.doGet(path, 404);
         } catch (ClientException e) {


### PR DESCRIPTION
## Description
Some improvements on the new `ErrorHandlerIT` ,  based on some additional feedback from #76

- Test against a random resource on `/content/test-site`  to aligns with other smoke tests
- Print detailed error message with explicit hint custom error handler implementations

Example error message:
```
[main] ERROR com.adobe.cq.cloud.testing.it.smoke.ErrorHandlerIT - Error handler test on publish failed. Getting a 200
response code when requesting the non-existing resource '/content/test-site/e6045446-8c5f-467f-9d69-3e007fa9ad71'.

This test explicitly asserts that requesting non-existing resources respond with a 404. If this is not the case, this usually
indicates to a flawed AEM error handler. If you use a custom error handler make sure it responds with a 404, see 
https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/developing/full-stack/custom-error-page.html?lang=en
```

## Related Issue
CQ-4353919


## Motivation and Context

## How Has This Been Tested?

* Running smoke test locally against an AEMCS
* Deployed artifact com.adobe.cq.cloud:com.adobe.cq.cloud.testing.it.smoke:0.20.5-SNAPSHOT
* Running smoke tests with this SNAPSHOT release using EAAS prod and EAAS CLI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
