### PR TITLE
Adding timeout change for replication test

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -194,8 +194,8 @@ public class ContentPublishRule extends ExternalResource {
                     log.info("Page check completed with status {}", slingHttpResponse.getStatusLine().getStatusCode());
                     return true;
                 });
-                // Changing the delay to be 1 minute so that the check page runs every minute
-                polling.poll(TIMEOUT_PER_TRY, 60000);
+                // Changing the delay to be 10 seconds so that the check page runs every 10 seconds
+                polling.poll(TIMEOUT_PER_TRY, 10000);
             } catch (TimeoutException te) {
                 throw getPublishException(getPageErrorCode(expectedStatus), errorMessage, polling.getLastException());
             } catch (InterruptedException e) {

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -69,8 +69,8 @@ public class ContentPublishRule extends ExternalResource {
     private static final Logger log = LoggerFactory.getLogger(ContentPublishRule.class);
     
     protected static final long TIMEOUT = TimeUnit.MINUTES.toMillis(5);
-    // Let the check page test run for 20 minutes
-    protected static final long TIMEOUT_PER_TRY = TimeUnit.MINUTES.toMillis(20);
+    // Let the check page test run for 10 minutes.
+    protected static final long TIMEOUT_PER_TRY = TimeUnit.MINUTES.toMillis(10);
 
     protected static final String PUBLISH_DIST_AGENT = "publish";
     private static final String PREVIEW_DIST_AGENT = "preview";

--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/rules/ContentPublishRule.java
@@ -69,7 +69,8 @@ public class ContentPublishRule extends ExternalResource {
     private static final Logger log = LoggerFactory.getLogger(ContentPublishRule.class);
     
     protected static final long TIMEOUT = TimeUnit.MINUTES.toMillis(5);
-    protected static final long TIMEOUT_PER_TRY = TimeUnit.MINUTES.toMillis(1);
+    // Let the check page test run for 20 minutes
+    protected static final long TIMEOUT_PER_TRY = TimeUnit.MINUTES.toMillis(20);
 
     protected static final String PUBLISH_DIST_AGENT = "publish";
     private static final String PREVIEW_DIST_AGENT = "preview";
@@ -193,7 +194,8 @@ public class ContentPublishRule extends ExternalResource {
                     log.info("Page check completed with status {}", slingHttpResponse.getStatusLine().getStatusCode());
                     return true;
                 });
-                polling.poll(TIMEOUT_PER_TRY, 1000);
+                // Changing the delay to be 1 minute so that the check page runs every minute
+                polling.poll(TIMEOUT_PER_TRY, 60000);
             } catch (TimeoutException te) {
                 throw getPublishException(getPageErrorCode(expectedStatus), errorMessage, polling.getLastException());
             } catch (InterruptedException e) {


### PR DESCRIPTION
Increasing timeout in order to allow for the status message to get back to the publishers 

## Description

Delay in publishers getting status message causing pipeline failures, increasing the timeout will give the test more time to perform.

## Motivation and Context

Pipelines are failing product test because the test is not waiting long enough


