### PR TITLE
Http clients honor system properties

### DIFF
--- a/smoke/pom.xml
+++ b/smoke/pom.xml
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>com.adobe.cq</groupId>
             <artifactId>aem-cloud-testing-clients</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
 
         <!-- logging -->


### PR DESCRIPTION
Http clients honor system properties

## Description

* Bump the AEM testing clients because of SLING-12086
* use the Sling testing client in ServiceAccessibleRule.java, based on https://github.com/adobe/aem-test-samples/commit/3be9a8f99a0dd450b21aa03fe85f963c505f7dbb



