### PR TITLE
SITES-16997 Disabled the testPersistedQueryEndpointAccessible test

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/PersistedQueryIT.java
@@ -24,6 +24,7 @@ import org.apache.sling.testing.clients.util.poller.Polling;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -53,6 +54,7 @@ public class PersistedQueryIT {
      * @throws InterruptedException in case if error is occurred
      * @throws TimeoutException     in case if error is occurred
      */
+    @Ignore
     @Test
     public void testPersistedQueryEndpointAccessible() throws InterruptedException, TimeoutException {
         new Polling() {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The persisted query liveness probe should only be valid when the persisted query feature is enabled on an AEM environment, otherwise, this will generate a false positive. 

As the identification of the environments with persisted query feature enabled is missing, diabling this test for now.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- SITES-16997

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
