### PR TITLE
fix: allow curly braces in password string

### DIFF
--- a/ui-cypress/test-module/cypress/support/commands.js
+++ b/ui-cypress/test-module/cypress/support/commands.js
@@ -34,7 +34,7 @@ Cypress.Commands.add('AEMLogin', function (username, password) {
     cy.get('#login').should('have.attr', 'action', '/libs/granite/core/content/login.html/j_security_check')
 
     cy.get('#username').type(username)
-    cy.get('#password').type(password, {log: false})
+    cy.get('#password').type(password, {log: false, parseSpecialCharSequences: false})
 
     cy.get('#submit-button').click()
     cy.get('coral-shell-content', {timeout: 5000}).should('exist')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

If for a chance the admin password contains curly braces 123{456} cypress will parse them trying to type the value into the password field.
this behavior has been disabled with this commit
https://docs.cypress.io/api/commands/type

## How Has This Been Tested?

running locally against an AEMCS instance in https://github.com/adobe/aem-guides-wknd/pull/438

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


