### PR TITLE
fixes #95 disable SearchIT

### DIFF
--- a/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/SearchIT.java
+++ b/smoke/src/main/java/com/adobe/cq/cloud/testing/it/smoke/SearchIT.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeoutException;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+@Ignore("https://github.com/adobe/aem-test-samples/issues/95")
 public class SearchIT {
 
     private static final long TIMEOUT = SECONDS.toMillis(30);


### PR DESCRIPTION
resolves #95 by adding `@Ignore` to the SearchIT class.

## Description

Skip the SearchIT test for product 

## Related Issue

#95 

## Motivation and Context

SearchIT times out for customers with `nt:base` index definitions during CM pipeline Product Tests phase.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
