### PR TITLE
ASSETS-62882 Update test to allow and match dynamic IDs

### DIFF
--- a/ui-cypress/test-module/cypress/e2e/assets.cy.js
+++ b/ui-cypress/test-module/cypress/e2e/assets.cy.js
@@ -48,8 +48,8 @@ describe('AEM Assets', () => {
         // Wait for any lazy loaded dialogs to appear
         cy.wait(3000)
 
-        // rename image
-        cy.get('input#dam-asset-upload-rename-input').clear().type(remoteImageName, {force: true});
+        // rename image (works with static or unique ID: dam-asset-upload-rename-input or dam-asset-upload-rename-input-{timestamp}-{random})
+        cy.get('input[id^="dam-asset-upload-rename-input"]').clear().type(remoteImageName, {force: true});
 
         // Press the upload button.
         cy.get('coral-dialog.is-open coral-dialog-footer [variant="primary"]').click({force: true});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Update asset upload Cypress test for dynamic rename input IDs**

https://jira.corp.adobe.com/browse/ASSETS-62882

## Description
The asset upload rename input in `fileupload.js` now appends index to create unique IDs (e.g. `dam-asset-upload-rename-input-{idx}`) if multiple files are uploaded. The first will be static ID `dam-asset-upload-rename-input`. 

This PR updates the Cypress test in `assets.cy.js` to target the rename input with an attribute selector that works for both the old static ID and the new unique IDs.



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[ASSETS-62882](https://jira.corp.adobe.com/browse/ASSETS-62882)

## Motivation and Context

The upload UI now assigns a unique ID per rename input to avoid ID collisions when multiple uploads or dialogs are in use. The test previously used `input#dam-asset-upload-rename-input`, which fails when the ID is dynamic. Using `input[id^="dam-asset-upload-rename-input"]` keeps the test passing for both the legacy static ID and the new unique IDs, so the test stays compatible with current and older AEM Assets behavior.


## How Has This Been Tested?

- This change to E2E requires testing against cloud AEM CS environments
- Cannot be tested against local AEM SDK jar because the assets.cy.js looks for `/content/dam.completeUpload.json` which will only be requested when using Asset [Binary Cloud Storage](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/admin/developer-reference-material-apis)
- Changes to the E2E test are needed to complete https://git.corp.adobe.com/CQ/dam/pull/13254/files 


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
